### PR TITLE
Warns on duplicate theorems + fixes 'iff' operator

### DIFF
--- a/src/acorn_value.rs
+++ b/src/acorn_value.rs
@@ -9,7 +9,7 @@ use crate::names::{ConstantName, DefinedName, InstanceName};
 use crate::token::TokenType;
 
 /// Represents a function application with a function and its arguments.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Hash, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct FunctionApplication {
     /// The function being applied
     pub function: Box<AcornValue>,
@@ -65,7 +65,7 @@ impl FunctionApplication {
 }
 
 /// Represents binary operators used in Acorn
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Hash, Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum BinaryOp {
     Implies,
     Equals,
@@ -218,7 +218,7 @@ impl ConstantInstance {
 
 /// Two AcornValue compare to equal if they are structurally identical.
 /// Comparison doesn't do any evaluations.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Hash, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum AcornValue {
     /// A variable that is bound to a value on the stack.
     /// Represented by (stack index, type).

--- a/src/environment/add_statement.rs
+++ b/src/environment/add_statement.rs
@@ -489,6 +489,15 @@ impl Environment {
             return Err(ts.claim.error(&message));
         }
 
+        let duplicate;
+
+        if self.theorems.contains(&external_claim) {
+            duplicate = true;
+        }else {
+            duplicate = false;
+            self.theorems.insert(external_claim.clone());
+        }
+
         let (premise, goal) = match &unbound_claim {
             AcornValue::Binary(BinaryOp::Implies, left, right) => {
                 let premise_range = match ts.claim.premise() {
@@ -552,6 +561,7 @@ impl Environment {
                     range,
                     premise,
                     goal,
+                    duplicate
                 ),
                 statement.first_line(),
                 statement.last_line(),

--- a/src/environment/env_base.rs
+++ b/src/environment/env_base.rs
@@ -33,6 +33,10 @@ pub struct Environment {
     /// Each node depends only on the nodes before it.
     pub nodes: Vec<Node>,
 
+    /// Theorems consist of theorem statements that need to be proven.
+    /// Used to check for duplicate theorems
+    pub theorems: HashSet<AcornValue>,
+
     /// Whether a plain "false" is anywhere in this environment.
     /// This indicates that the environment is supposed to have contradictory facts.
     pub includes_explicit_false: bool,
@@ -76,6 +80,7 @@ impl Environment {
             module_id,
             bindings: BindingMap::new(module_id),
             nodes: Vec::new(),
+            theorems: HashSet::new(),
             includes_explicit_false: false,
             first_line: 0,
             line_types: Vec::new(),
@@ -95,6 +100,7 @@ impl Environment {
             module_id: self.module_id,
             bindings: self.bindings.clone(),
             nodes: Vec::new(),
+            theorems: HashSet::new(),
             includes_explicit_false: false,
             first_line,
             line_types: Vec::new(),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -858,7 +858,7 @@ impl<'a> Evaluator<'a> {
                         Box::new(right_value),
                     )
                 }
-                TokenType::Equals => {
+                TokenType::Equals | TokenType::Iff => {
                     AcornType::Bool.check_eq(expected_type, token)?;
                     let left_value = self.evaluate_value_with_stack(stack, left, None)?;
                     let right_value =

--- a/src/project.rs
+++ b/src/project.rs
@@ -12,7 +12,7 @@ use walkdir::WalkDir;
 use crate::acorn_type::{AcornType, Datatype, Typeclass};
 use crate::acorn_value::AcornValue;
 use crate::binding_map::BindingMap;
-use crate::block::NodeCursor;
+use crate::block::{Node, NodeCursor};
 use crate::build_cache::BuildCache;
 use crate::builder::{BuildEvent, BuildStatus, Builder};
 use crate::code_generator::{self, CodeGenerator};
@@ -606,6 +606,19 @@ impl Project {
         loop {
             if cursor.requires_verification() {
                 let block_name = cursor.block_name();
+                // println!("{} at {} to {}", cursor.node(), cursor.node().first_line(), cursor.node().last_line());
+                match cursor.node() {
+                    Node::Block(b, _f) => {
+                        if b.is_duplicate_theorem {
+                            if cursor.node().has_goal() {
+                                // println!("Is a duplicate");
+                                let goalcontext = cursor.goal_context().unwrap();
+                                builder.log_proving_info(&goalcontext, "Duplicate Theorem");
+                            }
+                        }
+                    },
+                    _ => {},
+                }
                 if self.check_hashes
                     && module_hash
                         .matches_through_line(&old_module_cache, cursor.node().last_line())


### PR DESCRIPTION
Closes issue #6 and if there are two duplicate theorems, it returns a blue squiggly line (it does so by hashing AcornValues for each of the statements).