### PR TITLE
Parse type params expr by [ ] instead of < >

### DIFF
--- a/src/acorn_type.rs
+++ b/src/acorn_type.rs
@@ -126,7 +126,7 @@ impl PotentialType {
 
     /// If this potential type represents a base datatype, ie with no type parameters,
     /// return a reference to the datatype.
-    /// Thus, Nat is a base datatype, and List<T> is a base datatype, but List<Bool> is not.
+    /// Thus, Nat is a base datatype, and List[T] is a base datatype, but List[Bool] is not.
     pub fn as_base_datatype(&self) -> Option<&Datatype> {
         match self {
             PotentialType::Resolved(AcornType::Data(datatype, params)) => {
@@ -276,7 +276,7 @@ pub enum AcornType {
     /// For example, in:
     ///
     /// ```acorn
-    /// theorem reverse_twice<T>(list: List<T>) {
+    /// theorem reverse_twice[T](list: List[T]) {
     ///     // Imagine some proof here.
     ///     list.reverse.reverse = list
     /// }

--- a/src/acorn_type.rs
+++ b/src/acorn_type.rs
@@ -239,14 +239,14 @@ impl fmt::Display for TypeParam {
 impl TypeParam {
     /// Converts a list of type parameters to a string representation.
     pub fn params_to_str(params: &[TypeParam]) -> String {
-        let mut result = "<".to_string();
+        let mut result = "[".to_string();
         for (i, param) in params.iter().enumerate() {
             if i > 0 {
                 result.push_str(", ");
             }
             result.push_str(&format!("{}", param));
         }
-        result.push('>');
+        result.push(']');
         result
     }
 }
@@ -560,7 +560,7 @@ impl fmt::Display for AcornType {
             AcornType::Data(datatype, params) => {
                 write!(f, "{}", datatype.name)?;
                 if !params.is_empty() {
-                    write!(f, "<{}>", AcornType::types_to_str(params))?;
+                    write!(f, "[{}]", AcornType::types_to_str(params))?;
                 }
                 Ok(())
             }

--- a/src/acorn_value.rs
+++ b/src/acorn_value.rs
@@ -120,7 +120,7 @@ impl fmt::Display for ConstantInstance {
         write!(f, "{}", self.name)?;
         if !self.params.is_empty() {
             let types: Vec<_> = self.params.iter().map(|t| t.to_string()).collect();
-            write!(f, "<{}>", types.join(", "))?;
+            write!(f, "[{}]", types.join(", "))?;
         }
         Ok(())
     }

--- a/src/code_generator.rs
+++ b/src/code_generator.rs
@@ -306,7 +306,7 @@ impl CodeGenerator<'_> {
 
     /// Check if we can infer a function's type parameters from its argument types.
     ///
-    /// The key insight: if a function foo<P, Q> takes argument of type P,
+    /// The key insight: if a function foo[P, Q] takes argument of type P,
     /// we can't infer Q from just the argument. So we need explicit parameters.
     fn can_infer_type_params_from_args(&self, function: &AcornValue, args: &[AcornValue]) -> bool {
         // Get the constant and its parameters
@@ -706,7 +706,7 @@ impl CodeGenerator<'_> {
                                     let datatype_attr_name =
                                         DefinedName::datatype_attr(datatype, &attr);
                                     if !self.bindings.constant_name_in_use(&datatype_attr_name) {
-                                        // Generate DataType.attribute instead of Typeclass.attribute<DataType>
+                                        // Generate DataType.attribute instead of Typeclass.attribute[DataType]
                                         // only if the datatype doesn't override this attribute
                                         let lhs = self.type_to_expr(&c.params[0])?;
                                         let rhs = Expression::generate_identifier(&attr);
@@ -1068,7 +1068,7 @@ mod tests {
         p.mock(
             "/mock/pair.ac",
             r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -1080,7 +1080,7 @@ mod tests {
             from pair import Pair
             "#,
         );
-        p.check_code("main", "forall(x0: Pair<Bool, Bool>) { true }");
+        p.check_code("main", "forall(x0: Pair[Bool, Bool]) { true }");
         p.check_code(
             "main",
             "forall(x0: Bool, x1: Bool) { Pair.new(x0, x1).second = x1 }",
@@ -1093,7 +1093,7 @@ mod tests {
         p.mock(
             "/mock/pair.ac",
             r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -1105,7 +1105,7 @@ mod tests {
             import pair
             "#,
         );
-        p.check_code("main", "forall(x0: pair.Pair<Bool, Bool>) { true }");
+        p.check_code("main", "forall(x0: pair.Pair[Bool, Bool]) { true }");
     }
 
     #[test]
@@ -1114,12 +1114,12 @@ mod tests {
         p.mock(
             "/mock/pair.ac",
             r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
 
-            let pbbn: (Bool, Bool) -> Pair<Bool, Bool> = Pair<Bool, Bool>.new
+            let pbbn: (Bool, Bool) -> Pair[Bool, Bool] = Pair[Bool, Bool].new
             "#,
         );
         p.expect_ok("pair");
@@ -1132,12 +1132,12 @@ mod tests {
         p.mock(
             "/mock/pair.ac",
             r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
 
-            define double<T>(x: T) -> Pair<T, T> {
+            define double[T](x: T) -> Pair[T, T] {
                 Pair.new(x, x)
             }
             "#,
@@ -1157,12 +1157,12 @@ mod tests {
         p.mock(
             "/mock/pair.ac",
             r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
 
-            define double<T>(x: T) -> Pair<T, T> {
+            define double[T](x: T) -> Pair[T, T] {
                 Pair.new(x, x)
             }
             "#,
@@ -1246,7 +1246,7 @@ mod tests {
                 mul: (M, M) -> M
             }
 
-            theorem goal<M: Magma>(x: M) {
+            theorem goal[M: Magma](x: M) {
                 x * x = x
             }
             "#,
@@ -1268,7 +1268,7 @@ mod tests {
                 thing_property: Bool
             }
 
-            theorem goal<T: Thing>(x: T) {
+            theorem goal[T: Thing](x: T) {
                 x * x = x
             }
             "#,
@@ -1298,7 +1298,7 @@ mod tests {
                 bar_property: Bool
             }
 
-            theorem goal<B: Bar>(x: B) {
+            theorem goal[B: Bar](x: B) {
                 x + -x = B.zero + B.zero
             }
             "#,
@@ -1316,9 +1316,9 @@ mod tests {
                 item: F
             }
 
-            inductive List<T> {
+            inductive List[T] {
                 nil
-                cons(T, List<T>)
+                cons(T, List[T])
             }
 
             structure Bar {
@@ -1332,13 +1332,13 @@ mod tests {
             }
 
             theorem goal2 {
-                exists(a: List<Bool>) {
+                exists(a: List[Bool]) {
                     true
                 }
             }
 
-            theorem goal3<F: Foo> {
-                exists(a: List<F>) {
+            theorem goal3[F: Foo] {
+                exists(a: List[F]) {
                     true
                 }
             }
@@ -1351,8 +1351,8 @@ mod tests {
             "#,
         );
         p.check_goal_code("main", "goal1", "exists(k0: Bar) { true }");
-        p.check_goal_code("main", "goal2", "exists(k0: List<Bool>) { true }");
-        p.check_goal_code("main", "goal3", "exists(k0: List<F>) { true }");
+        p.check_goal_code("main", "goal2", "exists(k0: List[Bool]) { true }");
+        p.check_goal_code("main", "goal3", "exists(k0: List[F]) { true }");
         p.check_goal_code("main", "goal4", "exists(k0: Bool) { k0 }");
     }
 
@@ -1484,15 +1484,15 @@ mod tests {
             }
 
             theorem const_attr(b: Bar) {
-                Foo.flag<Bar>
+                Foo.flag[Bar]
             }
 
             theorem fn_attr(b: Bar) {
-                Foo.foo<Bar>(b)
+                Foo.foo[Bar](b)
             }
             "#,
         );
-        p.check_goal_code("main", "const_attr", "Foo.flag<Bar>");
-        p.check_goal_code("main", "fn_attr", "Foo.foo<Bar>(b)");
+        p.check_goal_code("main", "const_attr", "Foo.flag[Bar]");
+        p.check_goal_code("main", "fn_attr", "Foo.foo[Bar](b)");
     }
 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -118,8 +118,8 @@ impl<'a> Evaluator<'a> {
                 let Expression::Grouping(opening, expr, _) = params.as_ref() else {
                     return Err(params.error("expected type parameters in type application"));
                 };
-                if opening.token_type != TokenType::LessThan {
-                    return Err(opening.error("expected '<' for type params"));
+                if opening.token_type != TokenType::LeftBracket {
+                    return Err(opening.error("expected '[' for type params"));
                 }
                 let param_exprs = expr.flatten_comma_separated_list();
                 let mut instance_params = vec![];
@@ -933,7 +933,7 @@ impl<'a> Evaluator<'a> {
                 let arg_exprs = match args_expr.as_ref() {
                     Expression::Grouping(left_delimiter, e, _) => {
                         let exprs = e.flatten_comma_separated_list();
-                        if left_delimiter.token_type == TokenType::LessThan {
+                        if left_delimiter.token_type == TokenType::LeftBracket {
                             // This is a type parameter list
                             if let PotentialValue::Unresolved(unresolved) = function {
                                 let mut type_params = vec![];

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -179,9 +179,9 @@ impl fmt::Display for TypeParamExpr {
 
 impl TypeParamExpr {
     // Parses a type parameter list, if it's there.
-    // If the tokens don't start with '<', just return an empty list.
+    // If the tokens don't start with '[', just return an empty list.
     pub fn parse_list(tokens: &mut TokenIter) -> Result<Vec<TypeParamExpr>> {
-        if tokens.peek_type() != Some(TokenType::LessThan) {
+        if tokens.peek_type() != Some(TokenType::LeftBracket) {
             return Ok(vec![]);
         }
         tokens.next();
@@ -192,7 +192,7 @@ impl TypeParamExpr {
             let (typeclass, terminator) = if terminator.token_type == TokenType::Colon {
                 let (typeclass, terminator) = Expression::parse_type(
                     tokens,
-                    Terminator::Or(TokenType::Comma, TokenType::GreaterThan),
+                    Terminator::Or(TokenType::Comma, TokenType::RightBracket),
                 )?;
                 (Some(typeclass), terminator)
             } else {
@@ -200,14 +200,14 @@ impl TypeParamExpr {
             };
             params.push(TypeParamExpr { name, typeclass });
             match terminator.token_type {
-                TokenType::GreaterThan => {
+                TokenType::RightBracket => {
                     break;
                 }
                 TokenType::Comma => {
                     continue;
                 }
                 _ => {
-                    return Err(terminator.error("expected '>' or ',' after each type param"));
+                    return Err(terminator.error("expected ']' or ',' after each type param"));
                 }
             }
         }
@@ -375,9 +375,9 @@ impl Expression {
         Expression::generate_grouping(exprs, TokenType::LeftParen, TokenType::RightParen)
     }
 
-    // Generate a comma-separated grouping in angle brackets
+    // Generate a comma-separated grouping in square brackets
     pub fn generate_params(exprs: Vec<Expression>) -> Expression {
-        Expression::generate_grouping(exprs, TokenType::LessThan, TokenType::GreaterThan)
+        Expression::generate_grouping(exprs, TokenType::LeftBracket, TokenType::RightBracket)
     }
 
     // Generates a unary expression, parenthesizing if necessary according to precedence.
@@ -555,7 +555,6 @@ impl Expression {
     ) -> Result<(Expression, Token)> {
         let (mut partials, terminator) =
             parse_partial_expressions(tokens, expected_type, termination)?;
-        group_type_parameters(&mut partials)?;
         check_partial_expressions(&partials)?;
         let expression = combine_partial_expressions(partials, expected_type, &terminator)?;
         Ok((expression, terminator))
@@ -627,7 +626,7 @@ impl Expression {
         Expression::expect_parse(input, ExpressionType::Value)
     }
 
-    // For the purposes of this function, type params like <T, U> are considered types.
+    // For the purposes of this function, type params like [T, U] are considered types.
     pub fn is_type(&self) -> bool {
         match &self {
             Expression::Singleton(token) => token.is_type_name(),
@@ -657,10 +656,9 @@ enum PartialExpression {
     // Tokens that are only part of an expression
     Unary(Token),
 
-    // Binary includes < and > which might be used for type parameters.
     Binary(Token),
 
-    // An implicit binary expression, like "f(x)" or "List<Bool>".
+    // An implicit binary expression, like "f(x)" or "List[Bool]".
     // It's located between the f and the (x).
     Implicit(Token),
 }
@@ -711,13 +709,13 @@ fn parse_partial_expressions(
             return Ok((partials, token));
         }
 
-        if token.token_type == TokenType::LessThan && expected_type == ExpressionType::Type {
+        if token.token_type == TokenType::LeftBracket {
             // The start of a type parameter list.
             // If so, we need to parse the whole list as a single expression.
             let (subexpression, last_token) = Expression::parse(
                 tokens,
                 ExpressionType::Type,
-                Terminator::Is(TokenType::GreaterThan),
+                Terminator::Is(TokenType::RightBracket),
             )?;
             partials.push_back(PartialExpression::Implicit(token.clone()));
             let group = Expression::Grouping(token, Box::new(subexpression), last_token);
@@ -735,9 +733,7 @@ fn parse_partial_expressions(
                 }
                 (ExpressionType::Type, TokenType::Comma)
                 | (ExpressionType::Type, TokenType::RightArrow)
-                | (ExpressionType::Type, TokenType::Dot)
-                | (ExpressionType::Type, TokenType::LessThan)
-                | (ExpressionType::Type, TokenType::GreaterThan) => {
+                | (ExpressionType::Type, TokenType::Dot) => {
                     // These are okay in types
                 }
                 (ExpressionType::Type, _) => {
@@ -936,94 +932,6 @@ fn find_last_operator(partials: &VecDeque<PartialExpression>) -> Result<Option<u
     }
 }
 
-// Checks if this "looks like" a type parameter list.
-// It only has to find the innermost one when they are nested.
-// index is the index of the first partial expression after a '<'.
-// If so, returns the index of the closing '>'.
-fn looks_like_type_params(partials: &VecDeque<PartialExpression>, index: usize) -> Option<usize> {
-    for (i, partial) in partials.iter().enumerate().skip(index) {
-        match partial {
-            PartialExpression::Binary(token) => match token.token_type {
-                TokenType::Comma | TokenType::RightArrow | TokenType::Dot | TokenType::Colon => {
-                    continue
-                }
-                TokenType::GreaterThan => return Some(i),
-                _ => {
-                    return None;
-                }
-            },
-            PartialExpression::Expression(expr) => {
-                if expr.could_be_part_of_type() {
-                    continue;
-                }
-                return None;
-            }
-            _ => return None,
-        }
-    }
-    None
-}
-
-// Checks if anything in this list of partial expressions is actually type parameters.
-// Returns the indices of the '<' and '>' if so.
-fn find_type_params(partials: &VecDeque<PartialExpression>) -> Option<(usize, usize)> {
-    for (i, partial) in partials.iter().enumerate() {
-        match partial {
-            PartialExpression::Binary(token) => {
-                if token.token_type == TokenType::LessThan {
-                    if let Some(j) = looks_like_type_params(partials, i + 1) {
-                        return Some((i, j));
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
-// Checks if there are any type parameters in this list of partial expressions.
-// If so, it combines them into a single Grouping expression.
-// It's weird that sometimes we catch type parameters here and sometimes we catch them
-// while parsing partial expressions. It would be better to do it all in one place.
-fn group_type_parameters(partials: &mut VecDeque<PartialExpression>) -> Result<()> {
-    loop {
-        match find_type_params(&partials) {
-            Some((i, j)) => {
-                // Break into three groups.
-                // left, opening token, middle (the type parameters), closing token, right
-                // The left group is still called "partials".
-                let right = partials.split_off(j + 1);
-                let closing = partials.pop_back().unwrap();
-                let closing = match closing {
-                    PartialExpression::Binary(t) => t,
-                    _ => return Err(closing.error("expected a closing '>'")),
-                };
-                let middle = partials.split_off(i + 1);
-                let opening = partials.pop_back().unwrap();
-                let opening = match opening {
-                    PartialExpression::Binary(t) => t,
-                    _ => return Err(opening.error("expected an opening '<'")),
-                };
-
-                // Make a partial expression for the type params
-                let params = combine_partial_expressions(middle, ExpressionType::Type, &opening)?;
-                let grouped =
-                    Expression::Grouping(opening.clone(), Box::new(params), closing.clone());
-
-                // Reassemble the whole thing
-                partials.push_back(PartialExpression::Implicit(opening));
-                partials.push_back(PartialExpression::Expression(grouped));
-                if right.front().map_or(false, |p| p.is_grouping()) {
-                    partials.push_back(PartialExpression::Implicit(closing));
-                }
-                partials.extend(right);
-            }
-            None => return Ok(()),
-        }
-    }
-}
-
 // Checks to see if the partial expressions are valid.
 // This is not necessary for correctness. But we can generate a nicer error message here than
 // in the depths of a recursion.
@@ -1032,12 +940,6 @@ fn check_partial_expressions(partials: &VecDeque<PartialExpression>) -> Result<(
         // Iterate over all pairs
         for i in 0..(partials.len() - 1) {
             let left = &partials[i];
-            if let PartialExpression::Binary(t) = left {
-                if t.token_type == TokenType::GreaterThan {
-                    // Our sanity checks don't work for type parameters.
-                    continue;
-                }
-            }
             let right = &partials[i + 1];
             match (left, right) {
                 (PartialExpression::Binary(a), PartialExpression::Binary(b))
@@ -1548,20 +1450,20 @@ mod tests {
 
     #[test]
     fn test_generic_types() {
-        check_type("List<List<T>>");
-        check_type("List<List<X> -> List<Y>, List<Y> -> List<X>>");
-        check_type("List<(foo.Foo, bar.Bar) -> baz.Baz<Qux>>");
-        check_type("Pair<Bool, Bool>");
+        check_type("List[List[T]]");
+        check_type("List[List[X] -> List[Y], List[Y] -> List[X]]");
+        check_type("List[(foo.Foo, bar.Bar) -> baz.Baz[Qux]]");
+        check_type("Pair[Bool, Bool]");
     }
 
     #[test]
     fn test_type_params_in_expressions() {
-        check_value("foo<T>");
-        check_value("List<T>.new");
-        check_value("map(add<Int>, myList)");
-        check_value("is_surjective(identity<T>)");
-        check_value("foo.bar<T>");
-        check_value("maps_to<Bool, Bool>(not2, false)");
+        check_value("foo[T]");
+        check_value("List[T].new");
+        check_value("map(add[Int], myList)");
+        check_value("is_surjective(identity[T])");
+        check_value("foo.bar[T]");
+        check_value("maps_to[Bool, Bool](not2, false)");
     }
 
     #[test]
@@ -1571,11 +1473,16 @@ mod tests {
 
     #[test]
     fn test_multiple_type_params_in_argument() {
-        check_value("forall(p: Pair<Bool, Bool>) { true }");
+        check_value("forall(p: Pair[Bool, Bool]) { true }");
     }
 
     #[test]
     fn test_instantiated_method_expression() {
-        check_value("Pair<Foo, Bar>.new(foo, bar)");
+        check_value("Pair[Foo, Bar].new(foo, bar)");
+    }
+
+    #[test]
+    fn test_nested_generics_with_method() {
+        check_value("List[Pair[T1, T2]].new(nil)");
     }
 }

--- a/src/names.rs
+++ b/src/names.rs
@@ -23,7 +23,7 @@ impl fmt::Display for InstanceName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}.{}<{}>",
+            "{}.{}[{}]",
             self.typeclass.name, self.attribute, self.datatype.name
         )
     }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -1797,14 +1797,14 @@ where
     if type_params.is_empty() {
         return doc;
     }
-    let mut result = doc.append(allocator.text("<"));
+    let mut result = doc.append(allocator.text("["));
     for (i, param) in type_params.iter().enumerate() {
         if i > 0 {
             result = result.append(allocator.text(", "));
         }
         result = result.append(param.pretty_ref(allocator));
     }
-    result.append(allocator.text(">"))
+    result.append(allocator.text("]"))
 }
 
 fn write_args_pretty<'a, D, A>(

--- a/src/tests/env_misc_test.rs
+++ b/src/tests/env_misc_test.rs
@@ -181,7 +181,7 @@ fn test_forall_block_ending_with_exists() {
 #[test]
 fn test_type_params_cleaned_up() {
     let mut env = Environment::test();
-    env.add("define foo<T>(a: T) -> Bool { axiom }");
+    env.add("define foo[T](a: T) -> Bool { axiom }");
     assert!(env.bindings.get_type_for_typename("T").is_none());
 }
 

--- a/src/tests/env_parsing_test.rs
+++ b/src/tests/env_parsing_test.rs
@@ -88,7 +88,7 @@ fn test_template_typechecking() {
     let mut env = Environment::test();
     env.add("type Nat: axiom");
     env.add("let zero: Nat = axiom");
-    env.add("define eq<T>(a: T, b: T) -> Bool { a = b }");
+    env.add("define eq[T](a: T, b: T) -> Bool { a = b }");
     env.add("theorem t1 { eq(zero, zero) }");
     env.add("theorem t2 { eq(zero = zero, zero = zero) }");
     env.add("theorem t3 { eq(zero = zero, eq(zero, zero)) }");
@@ -500,7 +500,7 @@ fn test_cant_reuse_type_param_name() {
     let mut env = Environment::test();
     env.add(
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -510,7 +510,7 @@ fn test_cant_reuse_type_param_name() {
     // Reusing in a different scope is fine.
     env.add(
         r#"
-            structure Pair2<T, U> {
+            structure Pair2[T, U] {
                 first: T
                 second: U
             }
@@ -520,7 +520,7 @@ fn test_cant_reuse_type_param_name() {
     // Reusing a global name is not.
     env.bad(
         r#"
-            structure T<Pair, U> {
+            structure T[Pair, U] {
                 first: Pair
                 second: U
             }
@@ -542,7 +542,7 @@ fn test_no_params_on_member_functions() {
     env.bad(
         r#"
             attributes BoolPair {
-                define apply_first<T>(self, f: Bool -> T) -> T {
+                define apply_first[T](self, f: Bool -> T) -> T {
                     f(self.first)
                 }
             }
@@ -555,7 +555,7 @@ fn test_class_with_mismatched_num_params() {
     let mut env = Environment::test();
     env.add(
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -563,7 +563,7 @@ fn test_class_with_mismatched_num_params() {
     );
     env.bad(
         r#"
-            attributes Pair<T> {
+            attributes Pair[T] {
                 let t: Bool = true
             }
             "#,
@@ -575,7 +575,7 @@ fn test_structures_cant_reuse_param_names() {
     let mut env = Environment::test();
     env.bad(
         r#"
-            structure Pair<T, T> {
+            structure Pair[T, T] {
                 first: T
                 second: T
             }
@@ -588,7 +588,7 @@ fn test_struct_params_leave_scope() {
     let mut env = Environment::test();
     env.add(
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -606,7 +606,7 @@ fn test_class_params_leave_scope() {
     let mut env = Environment::test();
     env.add(
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -614,7 +614,7 @@ fn test_class_params_leave_scope() {
     );
     env.add(
         r#"
-            attributes Pair<T, U> {
+            attributes Pair[T, U] {
                 let t: T = axiom
                 let u: U = axiom
             }
@@ -645,12 +645,12 @@ fn test_no_templated_define_inside_proof() {
 
     env.bad(
         r#"
-            theorem baz<T> {
+            theorem baz[T] {
                 forall(x: T) {
                     true
                 }
             } by {
-                define qux<U>(x: U) -> Bool {
+                define qux[U](x: U) -> Bool {
                     true
                 }
             }
@@ -1337,7 +1337,7 @@ fn test_templated_recursive_function() {
                 zero
                 suc(Nat)
             }
-            define repeat<T>(n: Nat, f: T -> T, a: T) -> T {
+            define repeat[T](n: Nat, f: T -> T, a: T) -> T {
                 match n {
                     Nat.zero {
                         a
@@ -1666,7 +1666,7 @@ fn test_generic_structure() {
     let mut env = Environment::test();
     env.add(
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -1679,13 +1679,13 @@ fn test_generic_class_statement() {
     let mut env = Environment::test();
     env.add(
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
 
-            attributes Pair<T, U> {
-                define swap(self) -> Pair<U, T> {
+            attributes Pair[T, U] {
+                define swap(self) -> Pair[U, T] {
                     Pair.new(self.second, self.first)
                 }
             }
@@ -1698,7 +1698,7 @@ fn test_aliases_for_generics() {
     let mut env = Environment::test();
     env.add(
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -1706,7 +1706,7 @@ fn test_aliases_for_generics() {
     );
     env.add(
         r#"
-            type BoolPair: Pair<Bool, Bool>
+            type BoolPair: Pair[Bool, Bool]
             let truetrue: BoolPair = Pair.new(true, true)
             "#,
     );
@@ -1717,7 +1717,7 @@ fn test_theorem_with_instantiated_arg_type() {
     let mut env = Environment::test();
     env.add(
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -1725,7 +1725,7 @@ fn test_theorem_with_instantiated_arg_type() {
     );
     env.add(
         r#"
-            theorem goal(p: Pair<Bool, Bool>) {
+            theorem goal(p: Pair[Bool, Bool]) {
                 p.first = p.second or p.first = not p.second
             }
             "#,
@@ -1739,14 +1739,14 @@ fn test_methods_on_generic_classes() {
         r#"
             type Foo: axiom
             type Bar: axiom
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
             let f: Foo = axiom
             let b: Bar = axiom
-            let p1: Pair<Foo, Bar> = Pair.new(f, b)
-            let p2: Pair<Foo, Bar> = Pair<Foo, Bar>.new(f, b)
+            let p1: Pair[Foo, Bar] = Pair.new(f, b)
+            let p2: Pair[Foo, Bar] = Pair[Foo, Bar].new(f, b)
             "#,
     );
 
@@ -1754,7 +1754,7 @@ fn test_methods_on_generic_classes() {
     // But need this syntax to work for typeclasses anyway.
     env.add(
         r#"
-            let p3: Pair<Foo, Bar> = Pair.new<Foo, Bar>(f, b)
+            let p3: Pair[Foo, Bar] = Pair.new[Foo, Bar](f, b)
             "#,
     );
 }
@@ -1766,24 +1766,24 @@ fn test_generic_return_types() {
         r#"
             type Foo: axiom
             type Bar: axiom
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
             
-            attributes Pair<T, U> {
-                define swap(self) -> Pair<U, T> {
+            attributes Pair[T, U] {
+                define swap(self) -> Pair[U, T] {
                     Pair.new(self.second, self.first)
                 }
             }
 
-            let s: Pair<Foo, Bar> -> Pair<Bar, Foo> = Pair<Foo, Bar>.swap
+            let s: Pair[Foo, Bar] -> Pair[Bar, Foo] = Pair[Foo, Bar].swap
             let f: Foo = axiom
             let b: Bar = axiom
-            let p1: Pair<Foo, Bar> = Pair.new(f, b)
-            let p2: Pair<Bar, Foo> = p1.swap
-            let p3: Pair<Foo, Bar> = p2.swap
-            let p4: Pair<Foo, Bar> = p1.swap.swap
+            let p1: Pair[Foo, Bar] = Pair.new(f, b)
+            let p2: Pair[Bar, Foo] = p1.swap
+            let p3: Pair[Foo, Bar] = p2.swap
+            let p4: Pair[Foo, Bar] = p1.swap.swap
             "#,
     );
 }
@@ -1793,7 +1793,7 @@ fn test_aliasing_a_generic_type() {
     let mut env = Environment::test();
     env.add(
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -1871,7 +1871,7 @@ fn test_params_with_arg_application() {
         r#"
             type Nat: axiom
 
-            define maps_to<T, U>(f: T -> U, u: U) -> Bool {
+            define maps_to[T, U](f: T -> U, u: U) -> Bool {
                 exists(t: T) {
                     f(t) = u
                 }
@@ -1882,7 +1882,7 @@ fn test_params_with_arg_application() {
             }
 
             theorem foo {
-                maps_to<Bool, Bool>(not2, false)
+                maps_to[Bool, Bool](not2, false)
             }
         "#,
     );

--- a/src/tests/env_typeclass_test.rs
+++ b/src/tests/env_typeclass_test.rs
@@ -32,7 +32,7 @@ fn test_env_typeclass_in_define_template() {
             typeclass M: Magma {
                 mul: (M, M) -> M
             }
-            define true_fn<T: Magma>(a: T) -> Bool {
+            define true_fn[T: Magma](a: T) -> Bool {
                 true
             }
             "#,
@@ -47,7 +47,7 @@ fn test_env_typeclass_attributes() {
             typeclass M: Magma {
                 mul: (M, M) -> M
             }
-            define squared<T: Magma>(a: T) -> T {
+            define squared[T: Magma](a: T) -> T {
                 Magma.mul(a, a)
             }
             "#,
@@ -62,7 +62,7 @@ fn test_env_typeclass_instance_methods() {
             typeclass M: Magma {
                 mul: (M, M) -> M
             }
-            define squared<T: Magma>(a: T) -> T {
+            define squared[T: Magma](a: T) -> T {
                 a.mul(a)
             }
             "#,
@@ -77,7 +77,7 @@ fn test_env_typeclass_in_theorem_template() {
             typeclass M: Magma {
                 mul: (M, M) -> M
             }
-            theorem wrong_but_syntactic<Q: Magma>(a: Q, b: Q) {
+            theorem wrong_but_syntactic[Q: Magma](a: Q, b: Q) {
                 a.mul(b) = b.mul(a)
             }
             "#,
@@ -96,7 +96,7 @@ fn test_env_typechecking_with_typeclasses() {
     );
     env.bad(
         r#"
-            theorem wrong_by_typecheck<Q: Magma>(a: Q, b: Q) {
+            theorem wrong_by_typecheck[Q: Magma](a: Q, b: Q) {
                 a.mul(b) = b.mul
             }
             "#,
@@ -112,12 +112,12 @@ fn test_env_typeclass_in_structure() {
                 mul: (M, M) -> M
             }
             
-            structure MagmaPair<T: Magma> {
+            structure MagmaPair[T: Magma] {
                 first: T
                 second: T
             }
 
-            attributes MagmaPair<T: Magma> {
+            attributes MagmaPair[T: Magma] {
                 define prod(self) -> T {
                     self.first.mul(self.second)
                 }
@@ -135,7 +135,7 @@ fn test_env_typeclasses_match_between_structure_and_class() {
                 mul: (M, M) -> M
             }
             
-            structure MagmaPair<T> {
+            structure MagmaPair[T] {
                 first: T
                 second: T
             }
@@ -143,7 +143,7 @@ fn test_env_typeclasses_match_between_structure_and_class() {
     );
     env.bad(
         r#"
-            attributes MagmaPair<T: Magma> {
+            attributes MagmaPair[T: Magma] {
                 define prod(self) -> T {
                     self.first.mul(self.second)
                 }
@@ -162,7 +162,7 @@ fn test_env_operator_on_typeclass() {
             }
             
             // Not true but syntactically valid
-            theorem commutative<T: Magma>(a: T, b: T) {
+            theorem commutative[T: Magma](a: T, b: T) {
                 a * b = b * a
             }
             "#,
@@ -399,7 +399,7 @@ fn test_env_parametrizing_typeclass_constant() {
             }
 
             theorem goal {
-                Z2.zero = PointedSet.basepoint<Z2>
+                Z2.zero = PointedSet.basepoint[Z2]
             }
             "#,
     );
@@ -434,7 +434,7 @@ fn test_env_arbitrary_type_attributes() {
             typeclass F: Flagged {
                 flag: Bool
             }
-            theorem goal<F: Flagged> {
+            theorem goal[F: Flagged] {
                 F.flag or not F.flag
             }
             "#,
@@ -453,7 +453,7 @@ fn test_env_bool_not_instance_of_anything() {
         instance Foo: Flagged {
             let flag: Bool = true
         }
-        define get_flag<F: Flagged>(x: F) -> Bool {
+        define get_flag[F: Flagged](x: F) -> Bool {
             F.flag
         }
         "#,
@@ -480,7 +480,7 @@ fn test_env_typechecking_captures_instance_relationships() {
         instance Bar: Flagged {
             let flag: Bool = true
         }
-        define get_flag<F: Flagged>(x: F) -> Bool {
+        define get_flag[F: Flagged](x: F) -> Bool {
             F.flag
         }
         theorem goal_bar(b: Bar) {
@@ -510,7 +510,7 @@ fn test_env_typeclasses_can_have_conditions() {
             }
         }
 
-        theorem are_equal<S: Singleton>(a: S, b: S) {
+        theorem are_equal[S: Singleton](a: S, b: S) {
             a = b
         } by {
             Singleton.unique(a)
@@ -576,10 +576,10 @@ fn test_env_let_statements_with_params() {
             zero: P
         }
 
-        let z<P: PointedSet>: P = P.zero
+        let z[P: PointedSet]: P = P.zero
 
-        define is_zero<P: PointedSet>(x: P) -> Bool {
-            z<P> = x
+        define is_zero[P: PointedSet](x: P) -> Bool {
+            z[P] = x
         }
         "#,
     );
@@ -596,9 +596,9 @@ fn test_typeclass_codegen() {
                 bar: F
             }
 
-            let qux<F: Foo>: Bool = axiom
+            let qux[F: Foo]: Bool = axiom
 
-            theorem goal<F: Foo>(f: F) {
+            theorem goal[F: Foo](f: F) {
                 true
             }
         "#,
@@ -608,7 +608,7 @@ fn test_typeclass_codegen() {
     env.get_bindings("goal").expect_good_code("f + f");
     env.get_bindings("goal").expect_good_code("F.bar");
     env.get_bindings("goal").expect_good_code("F.add");
-    env.get_bindings("goal").expect_good_code("qux<F>");
+    env.get_bindings("goal").expect_good_code("qux[F]");
 }
 
 #[test]
@@ -644,7 +644,7 @@ fn test_env_handles_bad_typeclass_name_in_theorem() {
     let mut env = Environment::test();
     env.bad(
         r#"
-            theorem goal<F: Foo> {
+            theorem goal[F: Foo] {
                 true
             }
         "#,
@@ -656,15 +656,15 @@ fn test_env_handles_bad_typeclass_name_in_class_param() {
     let mut env = Environment::test();
     env.add(
         r#"
-            inductive List<T> {
+            inductive List[T] {
                 nil
-                cons(T, List<T>)
+                cons(T, List[T])
             }
             "#,
     );
     env.bad(
         r#"
-            attributes List<F: Foo> {
+            attributes List[F: Foo] {
                 let b: Bool = true
             }
         "#,
@@ -897,8 +897,8 @@ fn test_env_typeclass_with_numeral_attributes() {
                 bar_property: B -> Bool
             }
 
-            theorem goal<B: Bar>(b: B) {
-                B.0 = Foo.0<B>
+            theorem goal[B: Bar](b: B) {
+                B.0 = Foo.0[B]
             }
         "#,
     );
@@ -966,7 +966,7 @@ fn test_env_basic_typeclass_attributes() {
             instance Bar: Foo
 
             theorem test_typeclass_attribute(b: Bar) {
-                Foo.flag<Bar> = false
+                Foo.flag[Bar] = false
             }
 
             theorem test_instance_attribute(b: Bar) {
@@ -1011,7 +1011,7 @@ fn test_env_typeclass_attributes_no_type_params() {
     );
     env.bad(
         r#"
-            attributes F: Foo<T> {
+            attributes F: Foo[T] {
                 let flag: Bool = false
             }
         "#,
@@ -1122,12 +1122,12 @@ fn test_env_typeclass_operators() {
             }
             
             // Test operator on generic type with Addable constraint
-            theorem test_generic_addable<T: Addable>(a: T, b: T) {
+            theorem test_generic_addable[T: Addable](a: T, b: T) {
                 a + b = a
             }
             
             // Test operator on generic type with MoreAddable constraint
-            theorem test_generic_more_addable<T: MoreAddable>(a: T) {
+            theorem test_generic_more_addable[T: MoreAddable](a: T) {
                 a + T.zero = a
             }
         "#,
@@ -1164,7 +1164,7 @@ fn test_env_constant_attributes_on_extensions() {
             }
             
             theorem test_bar_flag {
-                Bar.flag<TestType> = true
+                Bar.flag[TestType] = true
             }
             
             theorem test_instance_flag(t: TestType) {
@@ -1188,7 +1188,7 @@ fn test_accessing_inherited_required_attributes() {
                 bar_flag: Bool
             }
 
-            theorem goal<B: Bar>(b: B) {
+            theorem goal[B: Bar](b: B) {
                 b.foo = B.foo_flag
             }
         "#,

--- a/src/tests/project_test.rs
+++ b/src/tests/project_test.rs
@@ -631,7 +631,7 @@ fn test_instance_separate_from_class_and_typeclass() {
         from pointed import Pointed
         import relate
 
-        define get_point<P: Pointed>(p: P) -> P {
+        define get_point[P: Pointed](p: P) -> P {
             P.origin
         }
 
@@ -748,24 +748,24 @@ fn test_hover_basic() {
     instance Nat: HasZero {                   // line 19
         let 0 = Nat.0                         // line 20
     }
-    theorem eq_zero<Z: HasZero>(a: Z) {       // line 22
+    theorem eq_zero[Z: HasZero](a: Z) {       // line 22
         a = Z.0                               // line 23
     } by {
         let b: Z = a                          // line 25
     }
     /// equals_doc_comment
-    define equals<T>(x: T, y: T) -> Bool {    // line 28
+    define equals[T](x: T, y: T) -> Bool {    // line 28
         x = y                             
     }
     let z_eq_z = equals(Nat.0, Nat.0)         // line 31
     /// num_doc_comment
     let num: Nat = make_nat(true)             // line 33
     /// List_doc_comment
-    inductive List<T> {                       // line 35
+    inductive List[T] {                       // line 35
         nil
-        cons(T, List<T>)
+        cons(T, List[T])
     }
-    let l = List.cons(num, List.nil<Nat>)     // line 39
+    let l = List.cons(num, List.nil[Nat])     // line 39
     // 34567890123456789012345678901
     let m: Nat satisfy {                      // line 41
         m = m
@@ -1054,7 +1054,7 @@ fn test_deep_required_attribute_lookup() {
         r#"
         from group import Group
 
-        define closure_constraint<G: Group>(contains: G -> Bool) -> Bool {
+        define closure_constraint[G: Group](contains: G -> Bool) -> Bool {
             forall(a: G, b: G) {
                 contains(a) and contains(b) implies contains(a * b)
             }
@@ -1171,7 +1171,7 @@ fn test_hover_typeclass_method_with_doc_comment() {
     let result = foo_instance.do_something              // line 20
     // 34567890123456789012345678901234567890
 
-    theorem goal<T: Thing>(t: T) {
+    theorem goal[T: Thing](t: T) {
         t.do_something
     }
     "#},

--- a/src/tests/prover_core_test.rs
+++ b/src/tests/prover_core_test.rs
@@ -559,7 +559,7 @@ fn test_templated_proof() {
             let t2: Thing = axiom
             let t3: Thing = axiom
             
-            define foo<T>(x: T) -> Bool { axiom }
+            define foo[T](x: T) -> Bool { axiom }
 
             axiom a12 { foo(t1) implies foo(t2) }
             axiom a23 { foo(t2) implies foo(t3) }
@@ -839,10 +839,10 @@ fn test_code_gen_not_losing_conclusion() {
 #[test]
 fn test_proving_identity_is_surjective() {
     // To prove this, the monomorphizer needs to instantiate the definitions of:
-    // is_surjective<V, V>
-    // identity<V>
+    // is_surjective[V, V]
+    // identity[V]
     let text = r#"
-            define is_surjective<T, U>(f: T -> U) -> Bool {
+            define is_surjective[T, U](f: T -> U) -> Bool {
                 forall(y: U) {
                     exists(x: T) {
                         f(x) = y
@@ -850,12 +850,12 @@ fn test_proving_identity_is_surjective() {
                 }
             }
 
-            define identity<T>(x: T) -> T {
+            define identity[T](x: T) -> T {
                 x
             }
 
-            theorem identity_is_surjective<V> {
-                is_surjective(identity<V>)
+            theorem identity_is_surjective[V] {
+                is_surjective(identity[V])
             }
         "#;
     verify_succeeds(text);
@@ -1729,7 +1729,7 @@ fn test_proving_with_inheritance() {
             bar_property: Bool
         }
 
-        axiom bar_has_foo_property<B: Bar> {
+        axiom bar_has_foo_property[B: Bar] {
             B.foo_property
         }
 
@@ -1737,7 +1737,7 @@ fn test_proving_with_inheritance() {
             baz_property: Bool
         }
 
-        theorem goal<B: Baz> {
+        theorem goal[B: Baz] {
             B.foo_property
         }
         "#,
@@ -1765,7 +1765,7 @@ fn test_proving_with_theorem_arg() {
             }
         }
 
-        theorem goal<T: Thing>(a: T, b: T, c: T) {
+        theorem goal[T: Thing](a: T, b: T, c: T) {
             a + b + c = b + c + a
         }
         "#,
@@ -1853,13 +1853,13 @@ fn test_proving_with_type_param() {
     p.mock(
         "/mock/main.ac",
         r#"
-        inductive List<T> {
+        inductive List[T] {
             nil
-            cons(T, List<T>)
+            cons(T, List[T])
         }
 
-        attributes List<T> {
-            define add(self, other: List<T>) -> List<T> {
+        attributes List[T] {
+            define add(self, other: List[T]) -> List[T] {
                 match self {
                     List.nil {
                         other
@@ -1871,8 +1871,8 @@ fn test_proving_with_type_param() {
             }
         }
 
-        theorem goal<T>(list: List<T>) {
-            list + List.nil<T> = list
+        theorem goal[T](list: List[T]) {
+            list + List.nil[T] = list
         }
         "#,
     );
@@ -1940,12 +1940,12 @@ fn test_proving_list_contains() {
     p.mock(
         "/mock/main.ac",
         r#"
-        inductive List<T> {
+        inductive List[T] {
             nil
-            cons(T, List<T>)
+            cons(T, List[T])
         }
 
-        attributes List<T> {
+        attributes List[T] {
             define contains(self, elem: T) -> Bool {
                 match self {
                     List.nil {
@@ -1962,15 +1962,15 @@ fn test_proving_list_contains() {
             }
         }
 
-        define finite_constraint<T>(contains: T -> Bool) -> Bool {
-            exists(superset: List<T>) {
+        define finite_constraint[T](contains: T -> Bool) -> Bool {
+            exists(superset: List[T]) {
                 forall(x: T) {
                     contains(x) implies superset.contains(x)
                 }
             }
         }
 
-        theorem goal<T>(ts: List<T>) {
+        theorem goal[T](ts: List[T]) {
             finite_constraint(ts.contains)
         }
         "#,
@@ -1989,18 +1989,18 @@ fn test_proving_needing_templates() {
             origin: P
         }
 
-        define foo<P: Pointed, Q: Pointed>(x: P) -> Q {
+        define foo[P: Pointed, Q: Pointed](x: P) -> Q {
             Q.origin
         }
 
-        define is_const<T, U>(f: T -> U) -> Bool {
+        define is_const[T, U](f: T -> U) -> Bool {
             forall(x: T, y: T) {
                 f(x) = f(y)
             }
         }
 
-        theorem goal<P: Pointed, Q: Pointed> {
-            is_const(foo<P, Q>)
+        theorem goal[P: Pointed, Q: Pointed] {
+            is_const(foo[P, Q])
         }
         "#,
     );

--- a/src/tests/prover_language_test.rs
+++ b/src/tests/prover_language_test.rs
@@ -142,7 +142,7 @@ fn test_prover_gets_structural_induction() {
 #[test]
 fn test_proving_parametric_theorem_basic() {
     let text = r#"
-            theorem goal<T>(a: T, b: T, c: T) {
+            theorem goal[T](a: T, b: T, c: T) {
                 a = b and b = c implies a = c
             } by {
                 if (a = b and b = c) {
@@ -156,7 +156,7 @@ fn test_proving_parametric_theorem_basic() {
 #[test]
 fn test_proving_parametric_theorem_no_block() {
     let text = r#"
-            theorem goal<T>(a: T, b: T, c: T) { a = b and b = c implies a = c }
+            theorem goal[T](a: T, b: T, c: T) { a = b and b = c implies a = c }
         "#;
     assert_eq!(prove_text(text, "goal"), Outcome::Success);
 }
@@ -167,7 +167,7 @@ fn test_citing_parametric_theorem() {
         r#"
             type Nat: axiom
             let zero: Nat = axiom
-            theorem foo<T>(a: T) { a = a }
+            theorem foo[T](a: T) { a = a }
             theorem goal { foo(zero) }
         "#,
     );
@@ -177,7 +177,7 @@ fn test_citing_parametric_theorem() {
 fn test_applying_parametric_function() {
     let text = r#"
             type Nat: axiom
-            define foo<T>(a: T) -> Bool { (a = a) }
+            define foo[T](a: T) -> Bool { (a = a) }
             let zero: Nat = axiom
             theorem goal { foo(zero) }
         "#;
@@ -187,8 +187,8 @@ fn test_applying_parametric_function() {
 #[test]
 fn test_parametric_definition_and_theorem() {
     let text = r#"
-            define foo<T>(a: T) -> Bool { axiom }
-            axiom foo_true<T>(a: T) { foo(a) }
+            define foo[T](a: T) -> Bool { axiom }
+            axiom foo_true[T](a: T) { foo(a) }
             type Nat: axiom
             let zero: Nat = axiom
             theorem goal { foo(zero) }
@@ -199,8 +199,8 @@ fn test_parametric_definition_and_theorem() {
 #[test]
 fn test_parameter_name_can_change() {
     let text = r#"
-            define foo<T>(a: T) -> Bool { axiom }
-            axiom foo_true<U>(a: U) { foo(a) }
+            define foo[T](a: T) -> Bool { axiom }
+            axiom foo_true[U](a: U) { foo(a) }
             type Nat: axiom
             let zero: Nat = axiom
             theorem goal { foo(zero) }
@@ -503,7 +503,7 @@ fn test_prove_with_recursive_function() {
             zero
             suc(Nat)
         }
-        define repeat<T>(n: Nat, f: T -> T, a: T) -> T {
+        define repeat[T](n: Nat, f: T -> T, a: T) -> T {
             match n {
                 Nat.zero {
                     a
@@ -656,18 +656,18 @@ fn test_proving_with_implies_keyword() {
 fn test_proving_with_generic_structure() {
     // Just testing that we can define something, then immediately prove the definition.
     let text = r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
 
-            attributes Pair<T, U> {
-                define swap(self) -> Pair<U, T> {
+            attributes Pair[T, U] {
+                define swap(self) -> Pair[U, T] {
                     Pair.new(self.second, self.first)
                 }
             }
 
-            theorem swap_def<T, U>(p: Pair<T, U>) {
+            theorem swap_def[T, U](p: Pair[T, U]) {
                 p.swap = Pair.new(p.second, p.first)
             }
         "#;
@@ -678,20 +678,20 @@ fn test_proving_with_generic_structure() {
 fn test_proving_with_generic_structure_definition() {
     // These theorems are direct implications of the structure definition.
     let text = r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
 
-            theorem check_first<T, U>(t: T, u: U) {
+            theorem check_first[T, U](t: T, u: U) {
                 Pair.new(t, u).first = t
             }
 
-            theorem check_second<T, U>(t: T, u: U) {
+            theorem check_second[T, U](t: T, u: U) {
                 Pair.new(t, u).second = u
             }
 
-            theorem check_new<T, U>(p: Pair<T, U>) {
+            theorem check_new[T, U](p: Pair[T, U]) {
                 Pair.new(p.first, p.second) = p
             }
         "#;
@@ -704,7 +704,7 @@ fn test_prove_with_imported_generic_structure() {
     p.mock(
         "/mock/pair.ac",
         r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -715,15 +715,15 @@ fn test_prove_with_imported_generic_structure() {
         r#"
             from pair import Pair
 
-            theorem check_first<T, U>(t: T, u: U) {
+            theorem check_first[T, U](t: T, u: U) {
                 Pair.new(t, u).first = t
             }
 
-            theorem check_second<T, U>(t: T, u: U) {
+            theorem check_second[T, U](t: T, u: U) {
                 Pair.new(t, u).second = u
             }
 
-            theorem check_new<T, U>(p: Pair<T, U>) {
+            theorem check_new[T, U](p: Pair[T, U]) {
                 Pair.new(p.first, p.second) = p
             }
         "#,
@@ -739,7 +739,7 @@ fn test_prove_with_imported_generic_structure() {
 #[test]
 fn test_proving_with_instance_of_generic_structure() {
     let text = r#"
-            structure Pair<T, U> {
+            structure Pair[T, U] {
                 first: T
                 second: U
             }
@@ -754,7 +754,7 @@ fn test_proving_with_instance_of_generic_structure() {
                 Pair.new(a, b).second = b
             }
 
-            theorem foo_pair_new(p: Pair<Foo, Foo>) {
+            theorem foo_pair_new(p: Pair[Foo, Foo]) {
                 Pair.new(p.first, p.second) = p
             }
         "#;
@@ -764,7 +764,7 @@ fn test_proving_with_instance_of_generic_structure() {
 #[test]
 fn test_proving_with_generic_constraint() {
     let text = r#"
-            structure EqCheckedPair<T> {
+            structure EqCheckedPair[T] {
                 first: T
                 second: T
                 eq: Bool
@@ -774,7 +774,7 @@ fn test_proving_with_generic_constraint() {
 
             type Foo: axiom
 
-            theorem check_constraint(p: EqCheckedPair<Foo>) {
+            theorem check_constraint(p: EqCheckedPair[Foo]) {
                 p.eq implies p.first = p.second
             }
         "#;
@@ -849,7 +849,7 @@ fn test_prover_handles_parametrized_constants() {
             }
 
             theorem goal {
-                Z1.zero = Singleton.value<Z1>
+                Z1.zero = Singleton.value[Z1]
             }
         "#;
     verify_succeeds(text);
@@ -909,7 +909,7 @@ fn test_prover_respects_typeclasses() {
                 one
             }
 
-            define is_equal<T>(x: T, y: T) -> Bool {
+            define is_equal[T](x: T, y: T) -> Bool {
                 x = y
             }
 
@@ -936,7 +936,7 @@ fn test_prover_can_use_typeclass_theorems() {
                 foo: F -> Bool
             }
 
-            axiom always_foo<F: Foo>(x: F) {
+            axiom always_foo[F: Foo](x: F) {
                 x.foo
             }
 
@@ -1015,7 +1015,7 @@ fn test_prover_handling_typeclasses() {
                 }
             }
 
-            theorem bar_true<G: FooTrue>(a: G) {
+            theorem bar_true[G: FooTrue](a: G) {
                 a.bar
             }
         "#;
@@ -1029,11 +1029,11 @@ fn test_use_typeclass_axiom_on_instance() {
                 b: Bool
             }
 
-            define foo<T>(t: T) -> Bool {
+            define foo[T](t: T) -> Bool {
                 axiom
             }
 
-            axiom foo_true<F: FooTrue>(a: F) {
+            axiom foo_true[F: FooTrue](a: F) {
                 foo(a)
             }
 
@@ -1059,11 +1059,11 @@ fn test_proving_with_parametrized_constant() {
                 point: P
             }
         
-            let get_point1<P: PointedSet>: P = P.point
-            let get_point2<P: PointedSet>: P = P.point
+            let get_point1[P: PointedSet]: P = P.point
+            let get_point2[P: PointedSet]: P = P.point
         
-            theorem goal<P: PointedSet> {
-                get_point1<P> = get_point2<P>
+            theorem goal[P: PointedSet] {
+                get_point1[P] = get_point2[P]
             }
         "#;
     verify_succeeds(text);
@@ -1072,12 +1072,12 @@ fn test_proving_with_parametrized_constant() {
 #[test]
 fn test_proving_with_parametrized_inductive() {
     let text = r#"
-            inductive List<T> {
+            inductive List[T] {
                 nil
-                cons(T, List<T>)
+                cons(T, List[T])
             }
 
-            define any(bs: List<Bool>) -> Bool {
+            define any(bs: List[Bool]) -> Bool {
                 match bs {
                     List.nil {
                         false
@@ -1089,7 +1089,7 @@ fn test_proving_with_parametrized_inductive() {
             }
 
             theorem goal {
-                exists(bs: List<Bool>) {
+                exists(bs: List[Bool]) {
                     any(bs)
                 }
             }
@@ -1100,12 +1100,12 @@ fn test_proving_with_parametrized_inductive() {
 #[test]
 fn test_proving_using_list_contains() {
     let text = r#"
-            inductive List<T> {
+            inductive List[T] {
                 nil
-                cons(T, List<T>)
+                cons(T, List[T])
             }
 
-            attributes List<T> {
+            attributes List[T] {
                 define contains(self, item: T) -> Bool {
                     match self {
                         List.nil {
@@ -1122,7 +1122,7 @@ fn test_proving_using_list_contains() {
                 }
             }
 
-            theorem tail_contains_imp_contains<T>(head: T, tail: List<T>, item: T) {
+            theorem tail_contains_imp_contains[T](head: T, tail: List[T], item: T) {
                 tail.contains(item) implies List.cons(head, tail).contains(item)
             }
         "#;
@@ -1132,10 +1132,10 @@ fn test_proving_using_list_contains() {
 #[test]
 fn test_proving_with_const_false() {
     let text = r#"
-            define const_false<T>(x: T) -> Bool {
+            define const_false[T](x: T) -> Bool {
                 false
             }
-            theorem goal<T>(x: T) {
+            theorem goal[T](x: T) {
                 not const_false(x)
             }
         "#;
@@ -1145,11 +1145,11 @@ fn test_proving_with_const_false() {
 #[test]
 fn test_proving_with_generic_let_attribute() {
     let text = r#"
-            structure Box<T> {
+            structure Box[T] {
                 item: T
             }
 
-            attributes Box<T> {
+            attributes Box[T] {
                 let const_false: T -> Bool = function(x: T) {
                     false
                 }
@@ -1165,16 +1165,16 @@ fn test_proving_with_generic_let_attribute() {
 #[test]
 fn test_proving_with_if_inside_match() {
     let text = r#"
-            inductive List<T> {
+            inductive List[T] {
                 nil
-                cons(T, List<T>)
+                cons(T, List[T])
             }
 
-            attributes List<T> {
-                define remove_all(self, item: T) -> List<T> {
+            attributes List[T] {
+                define remove_all(self, item: T) -> List[T] {
                     match self {
                         List.nil {
-                            List.nil<T>
+                            List.nil[T]
                         }
                         List.cons(head, tail) {
                             if head = item {
@@ -1187,8 +1187,8 @@ fn test_proving_with_if_inside_match() {
                 }
             }
 
-            theorem nil_remove_all<T>(item: T) {
-                List.nil<T>.remove_all(item) = List.nil<T>
+            theorem nil_remove_all[T](item: T) {
+                List.nil[T].remove_all(item) = List.nil[T]
             }
         "#;
     verify_succeeds(text);
@@ -1196,7 +1196,7 @@ fn test_proving_with_if_inside_match() {
 
 #[test]
 fn test_proving_with_typeclass_attribute_assigned_as_generic() {
-    // This requires us to monomorphize to match equals<Color>.
+    // This requires us to monomorphize to match equals[Color].
     let text = r#"
             typeclass F: Foo {
                 op: (F, F) -> Bool
@@ -1206,7 +1206,7 @@ fn test_proving_with_typeclass_attribute_assigned_as_generic() {
                 }
             }
 
-            define equals<T>(x: T, y: T) -> Bool {
+            define equals[T](x: T, y: T) -> Bool {
                 x = y
             }
 
@@ -1225,18 +1225,18 @@ fn test_proving_with_typeclass_attribute_assigned_as_generic() {
 #[test]
 fn test_proving_with_multiple_type_variables() {
     let text = r#"
-            inductive Nil<T> {
+            inductive Nil[T] {
                 nil
             }
 
-            let map<T, U>: (Nil<T>, T -> U) -> Nil<U> = axiom
-            let morph<T>: Nil<T> -> Nil<T> = axiom
+            let map[T, U]: (Nil[T], T -> U) -> Nil[U] = axiom
+            let morph[T]: Nil[T] -> Nil[T] = axiom
 
-            theorem goal<T, U>(items: Nil<T>, f: T -> U) {
+            theorem goal[T, U](items: Nil[T], f: T -> U) {
                 map(items, f) = morph(map(items, f))
             } by {
-                map(items, f) = Nil.nil<U>
-                morph(map(items, f)) = Nil.nil<U>
+                map(items, f) = Nil.nil[U]
+                morph(map(items, f)) = Nil.nil[U]
             }
         "#;
     verify_succeeds(text);
@@ -1251,7 +1251,7 @@ fn test_proving_with_mixin_instance() {
             inductive Foo {
                 foo
             }
-            let predicate<T>: T -> Bool = axiom
+            let predicate[T]: T -> Bool = axiom
 
             typeclass S: Stuff {
                 condition(s: S) {
@@ -1296,7 +1296,7 @@ fn test_proving_with_properties_of_base_typeclass() {
                 bar_property: Bool
             }
 
-            theorem goal<B: Bar> {
+            theorem goal[B: Bar] {
                 B.property
             }
         "#;
@@ -1322,7 +1322,7 @@ fn test_proving_with_deep_base_theorem() {
                 baz_property: Bool
             }
 
-            theorem goal<B: Baz>(a: B, b: B) {
+            theorem goal[B: Baz](a: B, b: B) {
                 a + b = b + a
             }
         "#;
@@ -1343,7 +1343,7 @@ fn test_typeclass_attribute_semantics() {
                 }
             }
             
-            theorem goal<A: Addable>(x: A) {
+            theorem goal[A: Addable](x: A) {
                 x.plus_zero = A.add(x, A.zero)
             }
         "#;
@@ -1399,10 +1399,10 @@ fn test_proving_with_default_required_attribute() {
 
             instance Foo: Arf
 
-            let diff<A: Arf> = (A.foo != A.bar)
+            let diff[A: Arf] = (A.foo != A.bar)
 
             theorem goal {
-                diff<Foo>
+                diff[Foo]
             }
         "#;
     verify_succeeds(text);

--- a/src/tests/statement_test.rs
+++ b/src/tests/statement_test.rs
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn test_theorem_with_type_parameter() {
         ok(indoc! {"
-        axiom recursion_base<T>(f: T -> T, a: T) {
+        axiom recursion_base[T](f: T -> T, a: T) {
             recursion(f, a, 0) = a
         }"});
     }
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn test_definition_with_type_parameter() {
         ok(indoc! {"
-        define recursion<T>(f: T -> T, a: T, n: Nat) -> Nat {
+        define recursion[T](f: T -> T, a: T, n: Nat) -> Nat {
             axiom
         }"});
     }
@@ -502,7 +502,7 @@ mod tests {
     #[test]
     fn test_parsing_structure_with_type_params() {
         ok(indoc! {"
-        structure Pair<T, U> {
+        structure Pair[T, U] {
             first: T
             second: U
         }"});
@@ -511,8 +511,8 @@ mod tests {
     #[test]
     fn test_parsing_attributes_statement_with_type_params() {
         ok(indoc! {"
-        attributes Pair<T, U> {
-            define swap(self) -> Pair<U, T> {
+        attributes Pair[T, U] {
+            define swap(self) -> Pair[U, T] {
                 Pair.new(self.second, self.first)
             }
         }"});
@@ -560,16 +560,16 @@ mod tests {
 
     #[test]
     fn test_parsing_parametrized_let_statements() {
-        ok("let foo<T>: T = bar<T>");
-        ok("let foo<T: Thing>: T = bar<T>");
+        ok("let foo[T]: T = bar[T]");
+        ok("let foo[T: Thing]: T = bar[T]");
     }
 
     #[test]
     fn test_parsing_parametrized_inductive_statement() {
         ok(indoc! {"
-        inductive List<T> {
+        inductive List[T] {
             nil
-            cons(T, List<T>)
+            cons(T, List[T])
         }"});
     }
 
@@ -635,7 +635,7 @@ mod tests {
     fn test_function_must_have_arguments() {
         fail_with(
             indoc! {"
-            define foo<T> -> Bool {
+            define foo[T] -> Bool {
                 true
             }"},
             "must have at least one argument",

--- a/src/token.rs
+++ b/src/token.rs
@@ -15,6 +15,8 @@ pub enum TokenType {
     RightParen,
     LeftBrace,
     RightBrace,
+    LeftBracket,
+    RightBracket,
     NewLine,
     Comma,
     Colon,
@@ -325,6 +327,8 @@ impl TokenType {
             TokenType::RightParen => ")",
             TokenType::LeftBrace => "{",
             TokenType::RightBrace => "}",
+            TokenType::LeftBracket => "[",
+            TokenType::RightBracket => "]",
             TokenType::NewLine => "\n",
             TokenType::Comma => ",",
             TokenType::Colon => ":",
@@ -591,6 +595,8 @@ impl Token {
             | TokenType::RightParen
             | TokenType::LeftBrace
             | TokenType::RightBrace
+            | TokenType::LeftBracket
+            | TokenType::RightBracket
             | TokenType::Colon
             | TokenType::Dot => None,
         }
@@ -626,6 +632,8 @@ impl Token {
                     ')' => TokenType::RightParen,
                     '{' => TokenType::LeftBrace,
                     '}' => TokenType::RightBrace,
+                    '[' => TokenType::LeftBracket,
+                    ']' => TokenType::RightBracket,
                     '\n' => TokenType::NewLine,
                     ',' => TokenType::Comma,
                     ':' => TokenType::Colon,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -383,7 +383,7 @@ mod tests {
                 bar_property: Bool
             }
 
-            axiom bar_has_foo_property<B: Bar> {
+            axiom bar_has_foo_property[B: Bar] {
                 B.foo_property
             }
 
@@ -400,7 +400,7 @@ mod tests {
             from foo import Baz
 
             // To prove this, we need to know that Baz extends Bar.
-            theorem baz_has_foo_property<B: Baz> {
+            theorem baz_has_foo_property[B: Baz] {
                 B.foo_property
             }
         "#,
@@ -443,7 +443,7 @@ mod tests {
                 bar_property: Bool
             }
 
-            axiom bar_has_foo_property<B: Bar> {
+            axiom bar_has_foo_property[B: Bar] {
                 B.foo_property
             }
 
@@ -452,7 +452,7 @@ mod tests {
             }
 
             // To prove this, we need to know that Baz extends Bar.
-            theorem baz_has_foo_property<B: Baz> {
+            theorem baz_has_foo_property[B: Baz] {
                 B.foo_property
             }
         "#,


### PR DESCRIPTION
As said in #8. For simplicity, I only change `< >` to `[ ]`. I use it to write some proof, and it work fine. Now I think another way is to use whitespace sensitivity to distinguish `<` for type params and `<` for order comparison, but this need more thing to change. `< >` in acornlib is also replaced by `[ ]` in https://github.com/ecbc0/acornlib/commit/ad69ab71c7dc9487f5ed11c771ff9823ea99b90a that can be PR.