### PR TITLE
feat(exporter): add source_block & attributes kind; fix nested define expansion (#42)

### DIFF
--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -51,9 +51,18 @@ pub struct ExportedModule {
     pub numerals: Option<String>,
     pub types: Vec<ExportedType>,
     pub typeclasses: Vec<ExportedTypeclass>,
+    pub attributes: Vec<ExportedAttributes>,
     pub instances: Vec<ExportedInstance>,
     pub definitions: Vec<ExportedDefinition>,
     pub theorems: Vec<ExportedTheorem>,
+}
+
+#[derive(Serialize)]
+pub struct ExportedAttributes {
+    pub type_name: String,
+    pub line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_block: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -64,6 +73,8 @@ pub struct ExportedType {
     pub doc_comments: Vec<String>,
     pub definition_string: Option<String>,
     pub line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_block: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -73,6 +84,8 @@ pub struct ExportedTypeclass {
     pub attributes: Vec<ExportedTypeclassAttribute>,
     pub doc_comments: Vec<String>,
     pub line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_block: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -87,6 +100,8 @@ pub struct ExportedInstance {
     pub type_name: String,
     pub typeclass: String,
     pub line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_block: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -97,6 +112,8 @@ pub struct ExportedDefinition {
     pub definition_body: Option<String>,
     pub doc_comments: Vec<String>,
     pub line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_block: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -128,6 +145,8 @@ pub struct ExportedTheorem {
     pub statement_annotations: Option<Vec<IdentifierInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proof_annotations: Option<Vec<IdentifierInfo>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_block: Option<String>,
 }
 
 #[derive(Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -313,6 +332,9 @@ fn write_jsonl(path: &Path, module: &ExportedModule) -> io::Result<()> {
     for tc in &module.typeclasses {
         write_json_line(&mut writer, "typeclass", tc)?;
     }
+    for attr in &module.attributes {
+        write_json_line(&mut writer, "attributes", attr)?;
+    }
     for inst in &module.instances {
         write_json_line(&mut writer, "instance", inst)?;
     }
@@ -418,6 +440,7 @@ fn export_module(
             doc_comments,
             definition_string,
             line,
+            source_block: None,
         });
     }
 
@@ -466,6 +489,7 @@ fn export_module(
             attributes,
             doc_comments,
             line,
+            source_block: None,
         });
     }
 
@@ -496,12 +520,168 @@ fn export_module(
 
     let numerals = bindings.numerals().map(|dt| dt.name.clone());
 
+    // ── Scan source for `attributes Type { ... }` blocks ────────────────
+    let mut attr_blocks: Vec<ExportedAttributes> = Vec::new();
+    for (i, line) in source_lines.iter().enumerate() {
+        if !line.starts_with(' ')
+            && !line.starts_with('\t')
+            && line.trim_start().starts_with("attributes ")
+        {
+            // Extract type name: "attributes Nat {" -> "Nat"
+            // or "attributes A: AddGroup {" -> "A: AddGroup"
+            let rest = line.trim_start().strip_prefix("attributes ").unwrap_or("");
+            let type_name = rest.split('{').next().unwrap_or("").trim().to_string();
+            attr_blocks.push(ExportedAttributes {
+                type_name,
+                line: (i + 1) as u32,
+                source_block: None,
+            });
+        }
+    }
+
+    // ── Populate source_block for every item ────────────────────────────
+    // Collect (1-based line, kind, index) for each exported item, sort by
+    // line, then slice source_lines between consecutive items.
+    //
+    // Only top-level items (no leading whitespace) participate in the
+    // range calculation. Nested items (definitions inside instance/
+    // attributes blocks) are excluded — they're part of their parent's
+    // source_block.
+    if !source_lines.is_empty() {
+        #[derive(Clone, Copy)]
+        enum ItemKind {
+            Type,
+            Typeclass,
+            Attributes,
+            Instance,
+            Definition,
+            Theorem,
+        }
+
+        let mut entries: Vec<(u32, ItemKind, usize)> = Vec::new();
+        for (i, t) in types.iter().enumerate() {
+            if t.line > 0 {
+                entries.push((t.line, ItemKind::Type, i));
+            }
+        }
+        for (i, t) in typeclasses.iter().enumerate() {
+            if t.line > 0 {
+                entries.push((t.line, ItemKind::Typeclass, i));
+            }
+        }
+        for (i, t) in attr_blocks.iter().enumerate() {
+            if t.line > 0 {
+                entries.push((t.line, ItemKind::Attributes, i));
+            }
+        }
+        for (i, t) in instances.iter().enumerate() {
+            if t.line > 0 {
+                entries.push((t.line, ItemKind::Instance, i));
+            }
+        }
+        for (i, t) in definitions.iter().enumerate() {
+            if t.line > 0 {
+                entries.push((t.line, ItemKind::Definition, i));
+            }
+        }
+        for (i, t) in theorems.iter().enumerate() {
+            if t.line > 0 {
+                entries.push((t.line, ItemKind::Theorem, i));
+            }
+        }
+
+        entries.sort_by_key(|(line, _, _)| *line);
+
+        // Determine which entries are top-level (no leading whitespace).
+        let is_top_level: Vec<bool> = entries
+            .iter()
+            .map(|(line, _, _)| {
+                let idx = (*line - 1) as usize;
+                if idx < source_lines.len() {
+                    let first_char = source_lines[idx].chars().next().unwrap_or(' ');
+                    !first_char.is_whitespace()
+                } else {
+                    false
+                }
+            })
+            .collect();
+
+        // Collect top-level lines for range boundary calculation.
+        let mut top_level_lines: Vec<u32> = entries
+            .iter()
+            .zip(is_top_level.iter())
+            .filter(|(_, &tl)| tl)
+            .map(|((line, _, _), _)| *line)
+            .collect();
+        top_level_lines.sort();
+        top_level_lines.dedup();
+
+        for idx in 0..entries.len() {
+            let (start_line, kind, item_idx) = entries[idx];
+            let mut start_0 = (start_line - 1) as usize; // to 0-based
+
+            if !is_top_level[idx] {
+                // Nested item: no source_block (it's part of the parent's block)
+                continue;
+            }
+
+            // Walk backwards to include doc comments (///) preceding this item
+            while start_0 > 0 && source_lines[start_0 - 1].trim().starts_with("///") {
+                start_0 -= 1;
+            }
+
+            // Find the next top-level item's line to determine range end
+            let end_0 = match top_level_lines.iter().find(|&&l| l > start_line) {
+                Some(&next_line) => {
+                    let next_line_0 = (next_line - 1) as usize;
+                    // Walk backwards to skip blank lines, imports, numerals,
+                    // and comments between items
+                    let mut end = next_line_0;
+                    while end > start_0 {
+                        let trimmed = source_lines[end - 1].trim();
+                        if trimmed.is_empty()
+                            || trimmed.starts_with("from ")
+                            || trimmed.starts_with("numerals ")
+                            || trimmed.starts_with("//")
+                        {
+                            end -= 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    end
+                }
+                None => {
+                    // Last top-level item: take to end of file
+                    let mut end = source_lines.len();
+                    while end > start_0 && source_lines[end - 1].trim().is_empty() {
+                        end -= 1;
+                    }
+                    end
+                }
+            };
+
+            if start_0 < end_0 && end_0 <= source_lines.len() {
+                let block: String = source_lines[start_0..end_0].join("\n");
+                match kind {
+                    ItemKind::Type => types[item_idx].source_block = Some(block),
+                    ItemKind::Typeclass => typeclasses[item_idx].source_block = Some(block),
+                    ItemKind::Attributes => attr_blocks[item_idx].source_block = Some(block),
+                    ItemKind::Instance => instances[item_idx].source_block = Some(block),
+                    ItemKind::Definition => definitions[item_idx].source_block = Some(block),
+                    ItemKind::Theorem => theorems[item_idx].source_block = Some(block),
+                }
+            }
+        }
+    }
+
     ExportedModule {
         name: module_name.to_string(),
         imports,
         numerals,
         types,
         typeclasses,
+        attributes: attr_blocks,
         instances,
         definitions,
         theorems,
@@ -578,6 +758,7 @@ fn export_node(
                 elaborated_proof: None,
                 statement_annotations: None,
                 proof_annotations: None,
+                source_block: None,
             });
         }
         Node::Block(block, external_fact, _) => {
@@ -686,6 +867,7 @@ fn export_node(
                             elaborated_proof,
                             statement_annotations,
                             proof_annotations,
+                            source_block: None,
                         });
                     }
                 }
@@ -794,6 +976,7 @@ fn export_fact(
                         elaborated_proof: None,
                         statement_annotations: None,
                         proof_annotations: None,
+                        source_block: None,
                     });
                 }
                 _ => {}
@@ -807,6 +990,7 @@ fn export_fact(
                 type_name: datatype.name.clone(),
                 typeclass: typeclass.name.clone(),
                 line: source.range.start.line + 1,
+                source_block: None,
             });
         }
         Fact::Definition(potential_value, definition, source) => {
@@ -837,6 +1021,7 @@ fn export_fact(
                 definition_body: def_body,
                 doc_comments,
                 line: source.range.start.line + 1,
+                source_block: None,
             });
         }
         Fact::Extends(_, _, _, _) => {}

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -663,6 +663,11 @@ fn export_module(
 
             if start_0 < end_0 && end_0 <= source_lines.len() {
                 let block: String = source_lines[start_0..end_0].join("\n");
+                let block = if let Some(ref num_type) = numerals {
+                    replace_bare_numerals(&block, num_type)
+                } else {
+                    block
+                };
                 match kind {
                     ItemKind::Type => types[item_idx].source_block = Some(block),
                     ItemKind::Typeclass => typeclasses[item_idx].source_block = Some(block),
@@ -1548,6 +1553,91 @@ fn dedent(text: &str) -> String {
         .join("\n")
 }
 
+/// Replace bare numeric literals with qualified form (e.g. `2` → `Nat.2`).
+///
+/// A bare numeral is a sequence of digits that is NOT:
+/// - preceded by `.` (already qualified like `Nat.2`)
+/// - preceded by `_` or an alphanumeric char (part of an identifier like `nat_base` or `T0`)
+/// - followed by `_` or an alphanumeric char
+///
+/// Lines starting with `//` (comments) are skipped.
+fn replace_bare_numerals(source: &str, numeral_type: &str) -> String {
+    source
+        .lines()
+        .map(|line| {
+            // Skip comment lines
+            if line.trim_start().starts_with("//") {
+                return line.to_string();
+            }
+            replace_numerals_in_line(line, numeral_type)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn replace_numerals_in_line(line: &str, numeral_type: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut result = String::with_capacity(line.len());
+    let mut i = 0;
+
+    while i < chars.len() {
+        // Check if we're at the start of a digit sequence
+        if chars[i].is_ascii_digit() {
+            // Check preceding character
+            let prev = if i > 0 { Some(chars[i - 1]) } else { None };
+            let is_qualified = prev == Some('.');
+            let is_ident = matches!(prev, Some(c) if c.is_alphanumeric() || c == '_');
+
+            // Check if this numeral is the name in a `let` or `define` statement
+            // e.g. "    let 2: Nat = ..." — the `2` is a definition name, not a value
+            let is_let_name = {
+                let prefix = result.trim();
+                prefix == "let" || prefix == "define"
+            };
+
+            if is_qualified || is_ident || is_let_name {
+                // Part of an identifier or already qualified — emit as-is
+                result.push(chars[i]);
+                i += 1;
+                continue;
+            }
+
+            // Collect the full number
+            let start = i;
+            while i < chars.len() && chars[i].is_ascii_digit() {
+                i += 1;
+            }
+
+            // Check following character
+            let next = if i < chars.len() {
+                Some(chars[i])
+            } else {
+                None
+            };
+            let followed_by_ident = matches!(next, Some(c) if c.is_alphanumeric() || c == '_');
+
+            if followed_by_ident {
+                // Part of identifier — emit as-is
+                for j in start..i {
+                    result.push(chars[j]);
+                }
+            } else {
+                // Bare numeral — qualify it
+                result.push_str(numeral_type);
+                result.push('.');
+                for j in start..i {
+                    result.push(chars[j]);
+                }
+            }
+        } else {
+            result.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1675,5 +1765,49 @@ mod tests {
         let output = Path::new("/tmp/export");
         let path = module_name_to_path(output, "prelude");
         assert_eq!(path, PathBuf::from("/tmp/export/prelude.jsonl"));
+    }
+
+    #[test]
+    fn test_replace_bare_numerals_basic() {
+        assert_eq!(
+            replace_bare_numerals("1 + 1 = 2", "Nat"),
+            "Nat.1 + Nat.1 = Nat.2"
+        );
+    }
+
+    #[test]
+    fn test_replace_bare_numerals_already_qualified() {
+        assert_eq!(replace_bare_numerals("Nat.0.suc", "Nat"), "Nat.0.suc");
+    }
+
+    #[test]
+    fn test_replace_bare_numerals_in_identifier() {
+        // Don't touch digits in identifiers
+        assert_eq!(
+            replace_bare_numerals("nat_base T0 x2y", "Nat"),
+            "nat_base T0 x2y"
+        );
+    }
+
+    #[test]
+    fn test_replace_bare_numerals_comment_skipped() {
+        assert_eq!(
+            replace_bare_numerals("// 1 + 1 = 2\nlet x = 3", "Nat"),
+            "// 1 + 1 = 2\nlet x = Nat.3"
+        );
+    }
+
+    #[test]
+    fn test_replace_bare_numerals_parens() {
+        assert_eq!(replace_bare_numerals("f(0, 1)", "Nat"), "f(Nat.0, Nat.1)");
+    }
+
+    #[test]
+    fn test_replace_bare_numerals_let_name() {
+        // In "let 2: Nat = ...", the 2 is a definition name, not a numeral value
+        assert_eq!(
+            replace_bare_numerals("    let 2: Nat = Nat.1.suc", "Nat"),
+            "    let 2: Nat = Nat.1.suc"
+        );
     }
 }

--- a/src/kernel/proof_step.rs
+++ b/src/kernel/proof_step.rs
@@ -1129,6 +1129,26 @@ impl ProofStep {
                     }),
                 )
             }
+            // Allow non-simplifying rewrites from factual definitions into
+            // hypothetical terms to remain shallow. Definition expansion is a
+            // fundamental proof step that should be explored early; marking it
+            // Deep causes the prover to exhaust its activation budget on other
+            // clauses before ever expanding nested definitions.
+            (Unspent, Unspent)
+                if !simplifying
+                    && pattern_step.truthiness == Truthiness::Factual
+                    && target_step.truthiness == Truthiness::Hypothetical =>
+            {
+                let pattern_root = pattern_step.shallow_opening_root(pattern_id);
+                let target_root = target_step.shallow_opening_root(target_id);
+                (
+                    Spent,
+                    Some(ShallowOrigin::Rewrite {
+                        pattern_id: pattern_root,
+                        target_id: target_root,
+                    }),
+                )
+            }
             _ => (Deep, None),
         }
     }

--- a/src/tests/prover/search_test.rs
+++ b/src/tests/prover/search_test.rs
@@ -836,3 +836,41 @@ fn test_proving_with_equality_resolution() {
         ],
     );
 }
+
+#[test]
+fn test_nested_define_expansion() {
+    // Regression test for https://github.com/acornprover/acorn/issues/42
+    // When an inner define has a complex exists-forall body, expanding the
+    // outer define must stay shallow so the prover finds the proof within
+    // the shallow activation budget.
+    let text = r#"
+        type Elem: axiom
+        let s: Elem -> Bool = axiom
+        let f: Elem -> Elem = axiom
+        let close: (Elem, Elem, Elem) -> Bool = axiom
+        let pos: Elem -> Bool = axiom
+
+        define inner(x: Elem) -> Bool {
+            s(x) and
+            forall(eps: Elem) {
+                pos(eps) implies exists(delta: Elem) {
+                    pos(delta) and forall(x1: Elem) {
+                        s(x1) and close(x1, x, delta) implies
+                        close(f(x1), f(x), eps)
+                    }
+                }
+            }
+        }
+
+        define outer(dummy: Elem) -> Bool {
+            forall(x: Elem) {
+                s(x) implies inner(x)
+            }
+        }
+
+        theorem goal(x: Elem) {
+            outer(x) and s(x) implies inner(x)
+        }
+        "#;
+    verify_succeeds(text);
+}


### PR DESCRIPTION
## Summary

### Exporter enhancements

- **`source_block` field** on all exported items (type, typeclass, instance, definition, theorem) — the original source code so `.ac` files can be
reconstructed from export data. Nested definitions inside `instance`/`attributes` blocks are excluded (part of parent's block).
- **`attributes` kind** — `attributes Type { ... }` blocks exported as first-class items.
- **Qualified numerals in source_block** — when a module has `numerals Nat`, bare `1` becomes `Nat.1` in source blocks, making them independent of
the `numerals` directive. Definition names preserved as-is (e.g., `let 2: Nat = Nat.1.suc`).

### Fix nested `define` expansion (fixes #42)

Non-simplifying rewrites from factual definitions into hypothetical terms were marked `Deep` in `rewrite_shallow_data`, causing the prover to
exhaust its activation budget before expanding nested definitions. Added a match arm to keep Factual→Hypothetical non-simplifying rewrites as
`Shallow (Spent)`.

## Test plan

- [x] `cargo test` — 1229 tests pass
- [x] `cargo run --profile release --features validate -- check` — 12594 stdlib certificates pass
- [x] Minimal reproduction case (nested define with exists-forall) now verifies
- [x] `cargo fmt` clean