### PR TITLE
Reduce memory allocations

### DIFF
--- a/src/elaborator/term_bridge.rs
+++ b/src/elaborator/term_bridge.rs
@@ -909,7 +909,7 @@ impl<'a> TermBridge<'a> {
                 ));
             }
 
-            if let Some(next_type) = remaining_head_type.type_apply_with_arg(arg) {
+            if let Some(next_type) = remaining_head_type.type_apply_with_arg(arg.as_ref()) {
                 remaining_head_type = next_type;
             }
         }

--- a/src/kernel/clause.rs
+++ b/src/kernel/clause.rs
@@ -288,9 +288,10 @@ impl Clause {
     }
 
     fn normalize_literals_for_clause(literal: Literal) -> Vec<Literal> {
-        let right = normalize_clause_term(&literal.right);
+        let right = normalize_clause_term(literal.right.as_ref());
         if right.is_true() {
-            let (left, positive) = normalize_signed_clause_term(&literal.left, literal.positive);
+            let (left, positive) =
+                normalize_signed_clause_term(literal.left.as_ref(), literal.positive);
             if let Some(args) = Self::split_symbol_application(&left, Symbol::Eq, 3) {
                 return vec![Literal::new(positive, args[1].clone(), args[2].clone())];
             }
@@ -299,7 +300,7 @@ impl Clause {
 
         vec![Literal::new(
             literal.positive,
-            normalize_clause_term(&literal.left),
+            normalize_clause_term(literal.left.as_ref()),
             right,
         )]
     }

--- a/src/kernel/kernel_context.rs
+++ b/src/kernel/kernel_context.rs
@@ -260,7 +260,7 @@ impl KernelContext {
             }
             let arg = type_args[type_arg_index].clone();
             witness = witness.apply(std::slice::from_ref(&arg));
-            witness_type = witness_type.type_apply_with_arg(&arg)?;
+            witness_type = witness_type.type_apply_with_arg(arg.as_ref())?;
             type_arg_index += 1;
         }
 
@@ -276,7 +276,7 @@ impl KernelContext {
             }
             let arg = self.find_inhabitant_with_seen(&input_type, local_context, seen)?;
             witness = witness.apply(std::slice::from_ref(&arg));
-            witness_type = witness_type.type_apply_with_arg(&arg)?;
+            witness_type = witness_type.type_apply_with_arg(arg.as_ref())?;
 
             if witness_type == *target_type {
                 return Some(witness);

--- a/src/kernel/term.rs
+++ b/src/kernel/term.rs
@@ -459,6 +459,13 @@ impl<'a> TermRef<'a> {
         }
     }
 
+    /// Check if this term contains any bound variables.
+    pub fn has_bound_variable(&self) -> bool {
+        self.components
+            .iter()
+            .any(|c| matches!(c, TermComponent::Atom(Atom::BoundVariable(_))))
+    }
+
     /// Split an existential quantifier into (binder_type, body).
     /// Returns None if the term is not an Exists.
     pub fn split_exists(&self) -> Option<(TermRef<'a>, TermRef<'a>)> {
@@ -618,8 +625,7 @@ impl<'a> TermRef<'a> {
                 // The function has type A -> B, so the application has type B
                 let func_type = func.get_type_with_context(local_context, kernel_context);
                 // For dependent types, we need to substitute the argument into the output type
-                let arg_term = arg.to_owned();
-                let result = func_type.type_apply_with_arg(&arg_term).unwrap_or_else(|| {
+                let result = func_type.type_apply_with_arg(arg).unwrap_or_else(|| {
                     panic!(
                         "Function type expected but not found during type application.\n\
                          func = {}\n\
@@ -790,8 +796,7 @@ impl<'a> TermRef<'a> {
                     kernel_context,
                 )?;
 
-                let arg_term = arg.to_owned();
-                func_type.type_apply_with_arg(&arg_term).ok_or_else(|| {
+                func_type.type_apply_with_arg(arg).ok_or_else(|| {
                     format!(
                         "Function type expected but not found during type application.\n\
                          func = {}\n\
@@ -1842,18 +1847,17 @@ impl Term {
     /// For non-dependent types like `A -> B`, this just returns B.
     /// For dependent types like `Pi(Type, b0 -> b0)`, applying `Int` gives `Int -> Int`.
     /// Returns None if this is not a Pi type.
-    pub fn type_apply_with_arg(&self, arg: &Term) -> Option<Term> {
+    pub fn type_apply_with_arg(&self, arg: TermRef<'_>) -> Option<Term> {
         self.as_ref().split_pi().map(|(_input, output)| {
-            let output = output.to_owned();
-            let result = if output.has_bound_variable() {
+            if output.has_bound_variable() {
                 // Dependent type: substitute and shift
-                let substituted = output.substitute_bound(0, arg);
+                let arg = arg.to_owned();
+                let substituted = output.to_owned().substitute_bound(0, &arg);
                 substituted.shift_bound(0, -1)
             } else {
-                // Non-dependent type: just return output
-                output
-            };
-            result
+                // Non-dependent type: just return output without touching arg
+                output.to_owned()
+            }
         })
     }
 
@@ -2624,12 +2628,7 @@ impl Term {
 
     /// Check if this term contains any bound variables.
     pub fn has_bound_variable(&self) -> bool {
-        for component in &self.components {
-            if let TermComponent::Atom(Atom::BoundVariable(_)) = component {
-                return true;
-            }
-        }
-        false
+        self.as_ref().has_bound_variable()
     }
 
     /// Check if this term has any bound variables that escape their enclosing Pi type.

--- a/src/kernel/term.rs
+++ b/src/kernel/term.rs
@@ -2457,17 +2457,32 @@ impl Term {
         if args.is_empty() {
             return self.clone();
         }
-        let mut result = self.clone();
-        for arg in args {
-            let right_offset = (1 + result.components.len()) as u16;
-            let mut components =
-                Vec::with_capacity(1 + result.components.len() + arg.components.len());
+        let n = args.len();
+        let self_len = self.components.len();
+        let total_args_len: usize = args.iter().map(|a| a.components.len()).sum();
+        let total_len = n + self_len + total_args_len;
+
+        let mut components = Vec::with_capacity(total_len);
+
+        // Layout: [App_outer, ..., App_inner, self_components, arg[0], ..., arg[n-1]]
+        // App at output index i (0 = outermost) has right_offset relative to its own subslice
+        // equal to (n - i) + self_len + sum(arg_lens[0..n-1-i]).
+        // We push outermost first and walk a running offset inward by subtracting
+        // (1 + arg_lens[n-2-i]) at each step.
+        let mut right_offset =
+            (n + self_len + total_args_len - args[n - 1].components.len()) as u16;
+        for i in 0..n {
             components.push(TermComponent::Application { right_offset });
-            components.extend(result.components.iter().copied());
-            components.extend(arg.components.iter().copied());
-            result = Term::from_components(components);
+            if i + 1 < n {
+                right_offset -= 1 + args[n - 2 - i].components.len() as u16;
+            }
         }
-        result
+        components.extend_from_slice(&self.components);
+        for arg in args {
+            components.extend_from_slice(&arg.components);
+        }
+
+        Term::from_components(components)
     }
 
     /// Build a term from a spine (function + arguments).

--- a/src/kernel/term/tests.rs
+++ b/src/kernel/term/tests.rs
@@ -279,7 +279,7 @@ fn test_polymorphic_type_application() {
     let correct_type = Term::pi(Term::type_sort(), Term::atom(Atom::BoundVariable(0)));
     let concrete_type = Term::parse("c0");
 
-    let result = correct_type.type_apply_with_arg(&concrete_type);
+    let result = correct_type.type_apply_with_arg(concrete_type.as_ref());
     assert!(result.is_some());
     assert_eq!(
         format!("{}", result.unwrap()),
@@ -293,7 +293,7 @@ fn test_free_variable_not_substituted_in_type_apply() {
     let pi_with_free = Term::pi(Term::type_sort(), Term::atom(Atom::FreeVariable(0)));
     let concrete_type = Term::parse("c0");
 
-    let result = pi_with_free.type_apply_with_arg(&concrete_type);
+    let result = pi_with_free.type_apply_with_arg(concrete_type.as_ref());
     assert!(result.is_some());
     assert_eq!(
         format!("{}", result.unwrap()),

--- a/src/kernel/term_normalization.rs
+++ b/src/kernel/term_normalization.rs
@@ -19,12 +19,25 @@ use crate::kernel::literal::Literal;
 use crate::kernel::symbol::Symbol;
 use crate::kernel::term::{Decomposition, Term, TermRef};
 
-fn split_symbol_application(term: &Term, symbol: Symbol, arity: usize) -> Option<Vec<Term>> {
-    let (head, args) = term.as_ref().split_application_multi()?;
+fn split_symbol_application<'a>(
+    term: TermRef<'a>,
+    symbol: Symbol,
+    arity: usize,
+) -> Option<Vec<TermRef<'a>>> {
+    if !term.is_application() {
+        return None;
+    }
+    let mut args = Vec::with_capacity(arity);
+    let mut current = term;
+    while let Some((func, arg)) = current.split_application() {
+        args.push(arg);
+        current = func;
+    }
     if args.len() != arity {
         return None;
     }
-    match head.get_head_atom() {
+    args.reverse();
+    match current.get_head_atom() {
         Atom::Symbol(s) if *s == symbol => Some(args),
         _ => None,
     }
@@ -196,24 +209,23 @@ fn eta_reduce_single_lambda(term: &Term) -> Option<Term> {
 }
 
 fn cancel_double_negation(term: &Term) -> Option<Term> {
-    let args = split_symbol_application(term, Symbol::Not, 1)?;
-    let inner_args = split_symbol_application(&args[0], Symbol::Not, 1)?;
-    Some(inner_args[0].clone())
+    let args = split_symbol_application(term.as_ref(), Symbol::Not, 1)?;
+    let inner_args = split_symbol_application(args[0], Symbol::Not, 1)?;
+    Some(inner_args[0].to_owned())
 }
 
 fn normalize_fully_applied_eq(term: &Term) -> Option<Term> {
-    let args = split_symbol_application(term, Symbol::Eq, 3)?;
-    let eq_type = args[0].clone();
-    let left = args[1].clone();
-    let right = args[2].clone();
+    let args = split_symbol_application(term.as_ref(), Symbol::Eq, 3)?;
+    let left = args[1];
+    let right = args[2];
     let already_ordered = match (left.atomic_variable(), right.atomic_variable()) {
         (Some(left_var), Some(right_var)) => left_var <= right_var,
-        _ => left <= right,
+        _ => left.to_owned() <= right.to_owned(),
     };
     if already_ordered {
         return None;
     }
-    Some(Term::eq(eq_type, right, left))
+    Some(Term::eq(args[0].to_owned(), right.to_owned(), left.to_owned()))
 }
 
 /// Recursively beta-reduces head lambda applications within an arbitrary term.
@@ -286,14 +298,14 @@ pub fn normalize_term(term: &Term) -> Term {
 /// This is the shared polarity-aware term rewriting used by clause normalization.
 /// It pushes `not` through the built-in boolean connectives and quantifiers, while
 /// preserving the historical clause-normalization behavior.
-pub(crate) fn normalize_clause_term_with_polarity(term: &Term, positive: bool) -> Term {
+pub(crate) fn normalize_clause_term_with_polarity(term: TermRef<'_>, positive: bool) -> Term {
     if let Some(args) = split_symbol_application(term, Symbol::Not, 1) {
-        return normalize_clause_term_with_polarity(&args[0], !positive);
+        return normalize_clause_term_with_polarity(args[0], !positive);
     }
 
     if let Some(args) = split_symbol_application(term, Symbol::And, 2) {
-        let left = normalize_clause_term_with_polarity(&args[0], positive);
-        let right = normalize_clause_term_with_polarity(&args[1], positive);
+        let left = normalize_clause_term_with_polarity(args[0], positive);
+        let right = normalize_clause_term_with_polarity(args[1], positive);
         return if positive {
             Term::and(left, right)
         } else {
@@ -302,8 +314,8 @@ pub(crate) fn normalize_clause_term_with_polarity(term: &Term, positive: bool) -
     }
 
     if let Some(args) = split_symbol_application(term, Symbol::Or, 2) {
-        let left = normalize_clause_term_with_polarity(&args[0], positive);
-        let right = normalize_clause_term_with_polarity(&args[1], positive);
+        let left = normalize_clause_term_with_polarity(args[0], positive);
+        let right = normalize_clause_term_with_polarity(args[1], positive);
         return if positive {
             Term::or(left, right)
         } else {
@@ -311,10 +323,10 @@ pub(crate) fn normalize_clause_term_with_polarity(term: &Term, positive: bool) -
         };
     }
 
-    match term.as_ref().decompose() {
+    match term.decompose() {
         Decomposition::ForAll(binder_type, body) => {
-            let binder_type = normalize_clause_term(&binder_type.to_owned());
-            let body = normalize_clause_term_with_polarity(&body.to_owned(), positive);
+            let binder_type = normalize_clause_term(binder_type);
+            let body = normalize_clause_term_with_polarity(body, positive);
             if positive {
                 Term::forall(binder_type, body)
             } else {
@@ -322,8 +334,8 @@ pub(crate) fn normalize_clause_term_with_polarity(term: &Term, positive: bool) -
             }
         }
         Decomposition::Exists(binder_type, body) => {
-            let binder_type = normalize_clause_term(&binder_type.to_owned());
-            let body = normalize_clause_term_with_polarity(&body.to_owned(), positive);
+            let binder_type = normalize_clause_term(binder_type);
+            let body = normalize_clause_term_with_polarity(body, positive);
             if positive {
                 Term::exists(binder_type, body)
             } else {
@@ -332,14 +344,14 @@ pub(crate) fn normalize_clause_term_with_polarity(term: &Term, positive: bool) -
         }
         Decomposition::Atom(_) => {
             if positive {
-                term.clone()
+                term.to_owned()
             } else {
-                Term::not(term.clone())
+                Term::not(term.to_owned())
             }
         }
         Decomposition::Application(function, argument) => {
-            let function = normalize_clause_term(&function.to_owned());
-            let argument = normalize_clause_term(&argument.to_owned());
+            let function = normalize_clause_term(function);
+            let argument = normalize_clause_term(argument);
             let rebuilt = function.apply(&[argument]);
             let rebuilt = normalize_fully_applied_eq(&rebuilt).unwrap_or(rebuilt);
             if positive {
@@ -349,8 +361,8 @@ pub(crate) fn normalize_clause_term_with_polarity(term: &Term, positive: bool) -
             }
         }
         Decomposition::Pi(input, output) => {
-            let input = normalize_clause_term(&input.to_owned());
-            let output = normalize_clause_term(&output.to_owned());
+            let input = normalize_clause_term(input);
+            let output = normalize_clause_term(output);
             let rebuilt = Term::pi(input, output);
             if positive {
                 rebuilt
@@ -359,8 +371,8 @@ pub(crate) fn normalize_clause_term_with_polarity(term: &Term, positive: bool) -
             }
         }
         Decomposition::Lambda(input, body) => {
-            let input = normalize_clause_term(&input.to_owned());
-            let body = normalize_clause_term(&body.to_owned());
+            let input = normalize_clause_term(input);
+            let body = normalize_clause_term(body);
             let rebuilt = Term::lambda(input, body);
             if positive {
                 rebuilt
@@ -372,20 +384,20 @@ pub(crate) fn normalize_clause_term_with_polarity(term: &Term, positive: bool) -
 }
 
 /// Normalize a term for clause normalization under positive polarity.
-pub(crate) fn normalize_clause_term(term: &Term) -> Term {
+pub(crate) fn normalize_clause_term(term: TermRef<'_>) -> Term {
     normalize_clause_term_with_polarity(term, true)
 }
 
 /// Normalize a signed boolean term for clause normalization, possibly changing both the term
 /// and its sign.
-pub(crate) fn normalize_signed_clause_term(term: &Term, positive: bool) -> (Term, bool) {
+pub(crate) fn normalize_signed_clause_term(term: TermRef<'_>, positive: bool) -> (Term, bool) {
     if let Some(args) = split_symbol_application(term, Symbol::Not, 1) {
-        return normalize_signed_clause_term(&args[0], !positive);
+        return normalize_signed_clause_term(args[0], !positive);
     }
 
     if let Some(args) = split_symbol_application(term, Symbol::Or, 2) {
-        let left = normalize_clause_term_with_polarity(&args[0], false);
-        let right = normalize_clause_term_with_polarity(&args[1], false);
+        let left = normalize_clause_term_with_polarity(args[0], false);
+        let right = normalize_clause_term_with_polarity(args[1], false);
         return (Term::and(left, right), !positive);
     }
 
@@ -627,21 +639,24 @@ mod tests {
     fn test_normalize_term_with_polarity_pushes_negation_through_or() {
         let term = Term::or(Term::parse("c0"), Term::parse("c1"));
         let expected = Term::and(Term::not(Term::parse("c0")), Term::not(Term::parse("c1")));
-        assert_eq!(normalize_clause_term_with_polarity(&term, false), expected);
+        assert_eq!(normalize_clause_term_with_polarity(term.as_ref(), false), expected);
     }
 
     #[test]
     fn test_normalize_signed_term_rewrites_signed_or() {
         let term = Term::or(Term::parse("c0"), Term::parse("c1"));
         let expected = Term::and(Term::not(Term::parse("c0")), Term::not(Term::parse("c1")));
-        assert_eq!(normalize_signed_clause_term(&term, true), (expected, false));
+        assert_eq!(
+            normalize_signed_clause_term(term.as_ref(), true),
+            (expected, false)
+        );
     }
 
     #[test]
     fn test_normalize_term_with_polarity_orders_fully_applied_eq() {
         let term = Term::eq(Term::bool_type(), Term::parse("c1"), Term::parse("c0"));
         let expected = Term::eq(Term::bool_type(), Term::parse("c0"), Term::parse("c1"));
-        assert_eq!(normalize_clause_term_with_polarity(&term, true), expected);
+        assert_eq!(normalize_clause_term_with_polarity(term.as_ref(), true), expected);
     }
 
     #[test]


### PR DESCRIPTION
Move to `Ref<>` in Term operations to save a few allocations/clones. Most of the change is just swapping wrappers to avoid allocations.
The only behaviour change in in `apply` which now tries to allocate the whole Vec ahead of time for a known size instead of extending it.

Tested on acornlib, reprove, and usual tests.

It *should* be functionally the same, but it's my first look under the covers of this project, so please check the details...

```
  ┌──────────────────────────────┬────────┬────────────────┬────────────────┐
  │            Stage             │  Mean  │ Δ vs. previous │ Δ vs. original │
  ├──────────────────────────────┼────────┼────────────────┼────────────────┤
  │ Original baseline            │ 317.4s │ —              │ —              │
  ├──────────────────────────────┼────────┼────────────────┼────────────────┤
  │ Clone-reduction commit       │ 276.5s │ −12.9%         │ −12.9%         │
  ├──────────────────────────────┼────────┼────────────────┼────────────────┤
  │ type_apply_with_arg refactor │ 270.4s │ −2.2%          │ −14.8%         │
  ├──────────────────────────────┼────────┼────────────────┼────────────────┤
```