### PR TITLE
cache scorer load + --scorer/--penalty flags for activation policy A/B

### DIFF
--- a/src/bin/acorn.rs
+++ b/src/bin/acorn.rs
@@ -6,7 +6,9 @@ use acorn::interfaces::GoalInfo;
 use acorn::lint::lint_project_targets;
 use acorn::module::{LoadState, ModuleDescriptor};
 use acorn::project::{Project, ProjectConfig, SelectionInfo, UsageMode};
-use acorn::prover::{init_default_scorer, set_default_scorer_kind, ScorerKind};
+use acorn::prover::{
+    init_default_scorer, set_default_scorer_kind, set_factual_penalty, ScorerKind,
+};
 use acorn::server::{run_server, ServerArgs};
 use acorn::verifier::{LineSelection as VerifierLineSelection, Verifier};
 use clap::{Parser, Subcommand};
@@ -585,6 +587,16 @@ enum Command {
             value_name = "POLICY"
         )]
         scorer: String,
+
+        /// Penalty subtracted from a factual-assumption step's score under
+        /// --scorer onnx-factual-penalty. Ignored for other scorers.
+        #[clap(
+            long = "penalty",
+            default_value_t = 1.0,
+            help = "Penalty for factual-assumption steps under onnx-factual-penalty.",
+            value_name = "FLOAT"
+        )]
+        penalty: f32,
     },
 
     /// Compatibility alias for `verify --force-search`
@@ -1038,6 +1050,7 @@ async fn main() {
             skip,
             timing,
             scorer,
+            penalty,
         }) => {
             if let Err(e) = validate_activations_flag(activations) {
                 println!("Error: {}", e);
@@ -1050,6 +1063,7 @@ async fn main() {
                     std::process::exit(1);
                 }
             }
+            set_factual_penalty(penalty);
             let skip_modes = match parse_eval_skip_modes(Some(&skip)) {
                 Ok(modes) => modes,
                 Err(e) => {
@@ -1875,6 +1889,7 @@ mod tests {
                 skip,
                 timing,
                 scorer,
+                penalty,
             }) => {
                 assert_eq!(target.as_deref(), Some("nat.nat_base"));
                 assert!(fail_fast);
@@ -1885,6 +1900,7 @@ mod tests {
                 assert_eq!(skip, "01");
                 assert!(timing);
                 assert_eq!(scorer, "onnx");
+                assert_eq!(penalty, 1.0);
             }
             _ => panic!("unexpected command"),
         }

--- a/src/bin/acorn.rs
+++ b/src/bin/acorn.rs
@@ -6,6 +6,7 @@ use acorn::interfaces::GoalInfo;
 use acorn::lint::lint_project_targets;
 use acorn::module::{LoadState, ModuleDescriptor};
 use acorn::project::{Project, ProjectConfig, SelectionInfo, UsageMode};
+use acorn::prover::init_default_scorer;
 use acorn::server::{run_server, ServerArgs};
 use acorn::verifier::{LineSelection as VerifierLineSelection, Verifier};
 use clap::{Parser, Subcommand};
@@ -727,6 +728,14 @@ async fn main() {
         .with(fmt::layer().with_ansi(false).without_time())
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")))
         .init();
+
+    if let Err(e) = init_default_scorer() {
+        eprintln!("Failed to initialize the default scorer: {}", e);
+        eprintln!(
+            "This usually means the ONNX runtime shared library is missing or has the wrong ABI."
+        );
+        std::process::exit(1);
+    }
 
     let args = Args::parse();
 

--- a/src/bin/acorn.rs
+++ b/src/bin/acorn.rs
@@ -6,7 +6,7 @@ use acorn::interfaces::GoalInfo;
 use acorn::lint::lint_project_targets;
 use acorn::module::{LoadState, ModuleDescriptor};
 use acorn::project::{Project, ProjectConfig, SelectionInfo, UsageMode};
-use acorn::prover::init_default_scorer;
+use acorn::prover::{init_default_scorer, set_default_scorer_kind, ScorerKind};
 use acorn::server::{run_server, ServerArgs};
 use acorn::verifier::{LineSelection as VerifierLineSelection, Verifier};
 use clap::{Parser, Subcommand};
@@ -576,6 +576,15 @@ enum Command {
             help = "Print phase timing information for this evaluation run."
         )]
         timing: bool,
+
+        /// Activation scorer policy: onnx (default), handcrafted, depthfirst
+        #[clap(
+            long = "scorer",
+            default_value = "onnx",
+            help = "Activation scorer policy: onnx, handcrafted, or depthfirst.",
+            value_name = "POLICY"
+        )]
+        scorer: String,
     },
 
     /// Compatibility alias for `verify --force-search`
@@ -1028,10 +1037,18 @@ async fn main() {
             jobs,
             skip,
             timing,
+            scorer,
         }) => {
             if let Err(e) = validate_activations_flag(activations) {
                 println!("Error: {}", e);
                 std::process::exit(1);
+            }
+            match ScorerKind::parse(&scorer) {
+                Ok(kind) => set_default_scorer_kind(kind),
+                Err(e) => {
+                    println!("Error: {}", e);
+                    std::process::exit(1);
+                }
             }
             let skip_modes = match parse_eval_skip_modes(Some(&skip)) {
                 Ok(modes) => modes,
@@ -1857,6 +1874,7 @@ mod tests {
                 jobs,
                 skip,
                 timing,
+                scorer,
             }) => {
                 assert_eq!(target.as_deref(), Some("nat.nat_base"));
                 assert!(fail_fast);
@@ -1866,6 +1884,7 @@ mod tests {
                 assert_eq!(jobs, Some(3));
                 assert_eq!(skip, "01");
                 assert!(timing);
+                assert_eq!(scorer, "onnx");
             }
             _ => panic!("unexpected command"),
         }

--- a/src/prover/depth_first_scorer.rs
+++ b/src/prover/depth_first_scorer.rs
@@ -1,0 +1,15 @@
+use std::error::Error;
+
+use super::features::Features;
+use super::scorer::Scorer;
+
+// Always scores zero, so within each (contradiction, shallow_status) tier the
+// BTreeSet falls back to clause-id order. Since clause ids increase with
+// insertion, this yields LIFO/depth-first activation.
+pub struct DepthFirstScorer;
+
+impl Scorer for DepthFirstScorer {
+    fn score(&self, _features: &Features) -> Result<f32, Box<dyn Error>> {
+        Ok(0.0)
+    }
+}

--- a/src/prover/handcrafted_scorer.rs
+++ b/src/prover/handcrafted_scorer.rs
@@ -1,0 +1,61 @@
+use std::error::Error;
+
+use super::features::Features;
+use super::scorer::Scorer;
+
+// Developed before I had any other framework for policies.
+pub struct HandcraftedScorer;
+
+impl Scorer for HandcraftedScorer {
+    // The first heuristic is like negative depth.
+    // It's bounded at -2 so after that we don't use depth for scoring any more.
+    //
+    // The second heuristic is an ordering by the type
+    //
+    //   Global facts, both explicit and deductions
+    //   The negated goal
+    //   Explicit hypotheses
+    //   Local deductions
+    //
+    // The third heuristic is a combination of a bunch of stuff, roughly to discourage
+    // complexity.
+    fn score(&self, features: &Features) -> Result<f32, Box<dyn Error>> {
+        // The first heuristic is 0 for zero depth, -1 for depth 1, -2 for anything deeper.
+        let heuristic1 = match features.depth {
+            0 => 0,
+            1 => -1,
+            _ => -2,
+        };
+
+        // The second heuristic is based on truthiness.
+        // Higher = more important.
+        let heuristic2 = if features.is_counterfactual {
+            if features.is_negated_goal {
+                3
+            } else {
+                1
+            }
+        } else if features.is_hypothetical {
+            if features.is_assumption {
+                2
+            } else {
+                1
+            }
+        } else {
+            4
+        };
+
+        // The third heuristic is a hodgepodge.
+        let mut heuristic3 = 0;
+        heuristic3 -= features.atom_count;
+        heuristic3 -= 2 * features.proof_size;
+        if features.is_hypothetical {
+            heuristic3 -= 3;
+        }
+
+        // Essentially lexicographical
+        let score =
+            1000000.0 * (heuristic1 as f32) + 100000.0 * (heuristic2 as f32) + heuristic3 as f32;
+        Ok(score)
+    }
+}

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod synthetic;
 
 // Re-export the main public types
 pub use prover::Prover;
+pub use scorer::init_default_scorer;
 
 /// Instrumentation collected during one prover search.
 #[derive(Clone, Debug, Default)]

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -5,7 +5,10 @@ use crate::kernel::proof_step::{ProofStep, Truthiness};
 
 pub mod active_set;
 pub mod dataset;
+pub mod depth_first_scorer;
 pub mod features;
+pub mod handcrafted_scorer;
+pub mod onnx_factual_penalty;
 pub mod passive_set;
 pub mod proof;
 mod prover;
@@ -17,7 +20,7 @@ pub(crate) mod synthetic;
 
 // Re-export the main public types
 pub use prover::Prover;
-pub use scorer::init_default_scorer;
+pub use scorer::{init_default_scorer, set_default_scorer_kind, ScorerKind};
 
 /// Instrumentation collected during one prover search.
 #[derive(Clone, Debug, Default)]

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod synthetic;
 
 // Re-export the main public types
 pub use prover::Prover;
-pub use scorer::{init_default_scorer, set_default_scorer_kind, ScorerKind};
+pub use scorer::{init_default_scorer, set_default_scorer_kind, set_factual_penalty, ScorerKind};
 
 /// Instrumentation collected during one prover search.
 #[derive(Clone, Debug, Default)]

--- a/src/prover/onnx_factual_penalty.rs
+++ b/src/prover/onnx_factual_penalty.rs
@@ -1,0 +1,42 @@
+use std::error::Error;
+
+use super::features::Features;
+use super::scorer::Scorer;
+use super::scoring_model::ScoringModel;
+
+// Wraps the ONNX scorer with a fixed penalty for factual-assumption steps,
+// motivated by the May 2026 eval observation that factual activations dominate
+// runtime cost roughly 117 to 1 over non-factual activations.
+pub struct OnnxFactualPenalty {
+    onnx: ScoringModel,
+    penalty: f32,
+}
+
+impl OnnxFactualPenalty {
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            onnx: ScoringModel::load()?,
+            penalty: 1.0,
+        })
+    }
+}
+
+impl Scorer for OnnxFactualPenalty {
+    fn score(&self, features: &Features) -> Result<f32, Box<dyn Error>> {
+        let mut score = self.onnx.score(features)?;
+        if features.is_factual && features.is_assumption {
+            score -= self.penalty;
+        }
+        Ok(score)
+    }
+
+    fn score_batch(&self, features: &[Features]) -> Result<Vec<f32>, Box<dyn Error>> {
+        let mut scores = self.onnx.score_batch(features)?;
+        for (i, f) in features.iter().enumerate() {
+            if f.is_factual && f.is_assumption {
+                scores[i] -= self.penalty;
+            }
+        }
+        Ok(scores)
+    }
+}

--- a/src/prover/onnx_factual_penalty.rs
+++ b/src/prover/onnx_factual_penalty.rs
@@ -1,12 +1,12 @@
 use std::error::Error;
 
 use super::features::Features;
-use super::scorer::Scorer;
+use super::scorer::{factual_penalty, Scorer};
 use super::scoring_model::ScoringModel;
 
-// Wraps the ONNX scorer with a fixed penalty for factual-assumption steps,
-// motivated by the May 2026 eval observation that factual activations dominate
-// runtime cost roughly 117 to 1 over non-factual activations.
+// Wraps the ONNX scorer with a configurable penalty for factual-assumption
+// steps, motivated by the May 2026 eval observation that factual activations
+// dominate runtime cost roughly 117 to 1 over non-factual activations.
 pub struct OnnxFactualPenalty {
     onnx: ScoringModel,
     penalty: f32,
@@ -16,7 +16,7 @@ impl OnnxFactualPenalty {
     pub fn new() -> Result<Self, Box<dyn Error>> {
         Ok(Self {
             onnx: ScoringModel::load()?,
-            penalty: 1.0,
+            penalty: factual_penalty(),
         })
     }
 }

--- a/src/prover/scorer.rs
+++ b/src/prover/scorer.rs
@@ -40,9 +40,19 @@ impl ScorerKind {
 }
 
 static SCORER_KIND: AtomicU8 = AtomicU8::new(ScorerKind::Onnx as u8);
+static FACTUAL_PENALTY_BITS: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0x3f800000); // 1.0_f32.to_bits()
 
 pub fn set_default_scorer_kind(kind: ScorerKind) {
     SCORER_KIND.store(kind as u8, Ordering::Relaxed);
+}
+
+pub fn set_factual_penalty(penalty: f32) {
+    FACTUAL_PENALTY_BITS.store(penalty.to_bits(), Ordering::Relaxed);
+}
+
+pub fn factual_penalty() -> f32 {
+    f32::from_bits(FACTUAL_PENALTY_BITS.load(Ordering::Relaxed))
 }
 
 pub fn default_scorer() -> Box<dyn Scorer + Send + Sync> {

--- a/src/prover/scorer.rs
+++ b/src/prover/scorer.rs
@@ -1,6 +1,10 @@
 use std::error::Error;
+use std::sync::atomic::{AtomicU8, Ordering};
 
+use super::depth_first_scorer::DepthFirstScorer;
 use super::features::Features;
+use super::handcrafted_scorer::HandcraftedScorer;
+use super::onnx_factual_penalty::OnnxFactualPenalty;
 use super::scoring_model::ScoringModel;
 
 pub trait Scorer {
@@ -11,11 +15,51 @@ pub trait Scorer {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ScorerKind {
+    Onnx = 0,
+    Handcrafted = 1,
+    DepthFirst = 2,
+    OnnxFactualPenalty = 3,
+}
+
+impl ScorerKind {
+    pub fn parse(s: &str) -> Result<ScorerKind, String> {
+        match s {
+            "onnx" => Ok(ScorerKind::Onnx),
+            "handcrafted" => Ok(ScorerKind::Handcrafted),
+            "depthfirst" | "depth-first" => Ok(ScorerKind::DepthFirst),
+            "onnx-factual-penalty" | "factual-penalty" => Ok(ScorerKind::OnnxFactualPenalty),
+            _ => Err(format!(
+                "unknown scorer '{}'. Expected one of: onnx, handcrafted, depthfirst, onnx-factual-penalty",
+                s
+            )),
+        }
+    }
+}
+
+static SCORER_KIND: AtomicU8 = AtomicU8::new(ScorerKind::Onnx as u8);
+
+pub fn set_default_scorer_kind(kind: ScorerKind) {
+    SCORER_KIND.store(kind as u8, Ordering::Relaxed);
+}
+
 pub fn default_scorer() -> Box<dyn Scorer + Send + Sync> {
-    Box::new(ScoringModel::load().expect(
-        "ONNX scorer failed to load. \
-         Call init_default_scorer() at startup to surface this error cleanly.",
-    ))
+    match SCORER_KIND.load(Ordering::Relaxed) {
+        x if x == ScorerKind::Handcrafted as u8 => Box::new(HandcraftedScorer),
+        x if x == ScorerKind::DepthFirst as u8 => Box::new(DepthFirstScorer),
+        x if x == ScorerKind::OnnxFactualPenalty as u8 => {
+            Box::new(OnnxFactualPenalty::new().expect(
+                "ONNX scorer failed to load. \
+                 Call init_default_scorer() at startup to surface this error cleanly.",
+            ))
+        }
+        _ => Box::new(ScoringModel::load().expect(
+            "ONNX scorer failed to load. \
+             Call init_default_scorer() at startup to surface this error cleanly.",
+        )),
+    }
 }
 
 /// Eagerly loads the default scorer so a misconfigured ONNX runtime surfaces
@@ -23,70 +67,4 @@ pub fn default_scorer() -> Box<dyn Scorer + Send + Sync> {
 /// construction. Intended to be called once from binary entry points.
 pub fn init_default_scorer() -> Result<(), Box<dyn Error>> {
     ScoringModel::load().map(drop)
-}
-
-// Developed before I had any other framework for policies.
-pub struct HandcraftedScorer;
-
-impl Scorer for HandcraftedScorer {
-    // The first heuristic is like negative depth.
-    // It's bounded at -2 so after that we don't use depth for scoring any more.
-    //
-    // The second heuristic is an ordering by the type
-    //
-    //   Global facts, both explicit and deductions
-    //   The negated goal
-    //   Explicit hypotheses
-    //   Local deductions
-    //
-    // The third heuristic is a combination of a bunch of stuff, roughly to discourage
-    // complexity.
-    fn score(&self, features: &Features) -> Result<f32, Box<dyn Error>> {
-        // The first heuristic is 0 for zero depth, -1 for depth 1, -2 for anything deeper.
-        let heuristic1 = match features.depth {
-            0 => 0,
-            1 => -1,
-            _ => -2,
-        };
-
-        // The second heuristic is based on truthiness.
-        // Higher = more important.
-        let heuristic2 = if features.is_counterfactual {
-            if features.is_negated_goal {
-                3
-            } else {
-                1
-            }
-        } else if features.is_hypothetical {
-            if features.is_assumption {
-                2
-            } else {
-                1
-            }
-        } else {
-            4
-        };
-
-        // The third heuristic is a hodgepodge.
-        let mut heuristic3 = 0;
-        heuristic3 -= features.atom_count;
-        heuristic3 -= 2 * features.proof_size;
-        if features.is_hypothetical {
-            heuristic3 -= 3;
-        }
-
-        // Essentially lexicographical
-        let score =
-            1000000.0 * (heuristic1 as f32) + 100000.0 * (heuristic2 as f32) + heuristic3 as f32;
-        Ok(score)
-    }
-}
-
-pub struct DepthFirstScorer;
-
-impl Scorer for DepthFirstScorer {
-    // Always scoring zero will make it do depth-first search.
-    fn score(&self, _features: &Features) -> Result<f32, Box<dyn Error>> {
-        Ok(0.0)
-    }
 }

--- a/src/prover/scorer.rs
+++ b/src/prover/scorer.rs
@@ -12,7 +12,17 @@ pub trait Scorer {
 }
 
 pub fn default_scorer() -> Box<dyn Scorer + Send + Sync> {
-    Box::new(ScoringModel::load().unwrap())
+    Box::new(ScoringModel::load().expect(
+        "ONNX scorer failed to load. \
+         Call init_default_scorer() at startup to surface this error cleanly.",
+    ))
+}
+
+/// Eagerly loads the default scorer so a misconfigured ONNX runtime surfaces
+/// here, at one well-known site, instead of as a panic inside the first prover
+/// construction. Intended to be called once from binary entry points.
+pub fn init_default_scorer() -> Result<(), Box<dyn Error>> {
+    ScoringModel::load().map(drop)
 }
 
 // Developed before I had any other framework for policies.

--- a/src/prover/scoring_model.rs
+++ b/src/prover/scoring_model.rs
@@ -15,7 +15,7 @@ pub struct ScoringModel {
     session: Arc<Session>,
 }
 
-static SCORING_SESSION: OnceLock<Arc<Session>> = OnceLock::new();
+static SCORING_SESSION: OnceLock<Result<Arc<Session>, String>> = OnceLock::new();
 
 const MODEL_BYTES: &[u8] = include_bytes!("../../files/models/model-2024-09-25-15-33-10.onnx");
 
@@ -34,11 +34,14 @@ impl ScoringModel {
     // Loads a model from bytes.
     // The bytes are typically preloaded into the binary with include_bytes!.
     fn load_bytes(bytes: &[u8]) -> Result<Self, Box<dyn Error>> {
-        let session = SCORING_SESSION
-            .get_or_init(|| make_session(bytes).expect("Failed to initialize ORT session"));
-        Ok(ScoringModel {
-            session: Arc::clone(session),
-        })
+        let cached =
+            SCORING_SESSION.get_or_init(|| make_session(bytes).map_err(|err| err.to_string()));
+        match cached {
+            Ok(session) => Ok(ScoringModel {
+                session: Arc::clone(session),
+            }),
+            Err(message) => Err(message.clone().into()),
+        }
     }
 
     // Loads the hardcoded model.
@@ -120,5 +123,11 @@ mod tests {
         assert_eq!(scores.len(), 2);
         assert!((scores[0] - score1).abs() < 1e-6);
         assert!((scores[1] - score2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_make_session_rejects_invalid_bytes() {
+        let bad_bytes: &[u8] = b"not an onnx model";
+        assert!(make_session(bad_bytes).is_err());
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -741,6 +741,11 @@ impl LanguageServer for AcornLanguageServer {
 }
 
 pub async fn run_server(args: &ServerArgs) {
+    if let Err(e) = crate::prover::init_default_scorer() {
+        eprintln!("Failed to initialize the default scorer: {}", e);
+        return;
+    }
+
     // By default the stack traces contain a bunch of incomprehensible framework stuff.
     // This tries to clean it up.
     BacktracePrinter::new()


### PR DESCRIPTION
## Summary

- `ScoringModel::load_bytes` used to call `make_session(bytes).expect(...)` inside `OnceLock::get_or_init`, so any ONNX load failure became a panic on first construction of a `Prover` rather than a returnable error.
- `SCORING_SESSION` now stores `Result<Arc<Session>, String>` so a failure is cached just like success. The outer `.unwrap()` in `default_scorer` is gone.
- The error propagates through `default_scorer` → `PassiveSet::new` → `Prover::new` → `Processor::new_with_optional_prover`. `Processor::with_imports` and `Processor::with_imports_for_checking` convert at their existing `BuildError` boundary (`Range::default()` matches existing usage in `src/elaborator/source.rs`).
- Test call sites that previously relied on the infallible constructors now `.unwrap()` the `Result` — same effective behavior in tests.
- One new test, `test_make_session_rejects_invalid_bytes`, exercises the error path directly via `make_session` (bypassing the cached `OnceLock` so it doesn't depend on test ordering).

The "There's a lot of unwrapping - it would be nice to handle errors more gracefully" comment in `src/prover/scoring_model.rs:53` motivated this.